### PR TITLE
Use debian/ubuntu-core-launcher.maintscript and fix mainthelper failure

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Description: Launcher for snappy apps
  This package contains the launcher for applications packaged as snaps
 
 Package: ubuntu-core-launcher
-Architecture: all
+# dpkg-mainthelper fails to remove the conffile if we switch from any to all
+Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, snap-run
 Pre-Depends: dpkg (>= 1.17.14)
 Description: Launcher for ubuntu-core (snappy) apps

--- a/debian/ubuntu-core-launcher.maintscript
+++ b/debian/ubuntu-core-launcher.maintscript
@@ -1,0 +1,2 @@
+# we don't need this anymore
+rm_conffile /etc/apparmor.d/usr.bin.ubuntu-core-launcher 2.0~

--- a/debian/ubuntu-core-launcher.postinst
+++ b/debian/ubuntu-core-launcher.postinst
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-# XXX: doesn't seem to really work in practice. Perhaps the version needs love
-dpkg-maintscript-helper rm_conffile \
-    /etc/apparmor.d/usr.bin.ubuntu-core-launcher 2.0~ -- "$@"
-
 case $1 in
     configure)
         # remove current profile so that the pass-through can still run

--- a/debian/ubuntu-core-launcher.postrm
+++ b/debian/ubuntu-core-launcher.postrm
@@ -1,3 +1,0 @@
-#!/bin/sh
-dpkg-maintscript-helper rm_conffile \
-    /etc/apparmor.d/usr.bin.ubuntu-core-launcher 2.0~ -- "$@"

--- a/debian/ubuntu-core-launcher.preinst
+++ b/debian/ubuntu-core-launcher.preinst
@@ -1,3 +1,0 @@
-#!/bin/sh
-dpkg-maintscript-helper rm_conffile \
-    /etc/apparmor.d/usr.bin.ubuntu-core-launcher 2.0~ -- "$@"


### PR DESCRIPTION
dpkg-mainthelper does not deal with the switch from arch:any -> arch:all.
