### PR TITLE
Discard the useless duplicate argument

### DIFF
--- a/compat/ubuntu-core-launcher
+++ b/compat/ubuntu-core-launcher
@@ -1,2 +1,3 @@
 #!/bin/sh
+shift
 exec /usr/bin/snap-run "$@"

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,10 @@ ubuntu-core-launcher (2.0) UNRELEASED; urgency=medium
   * Allow for graceful migrations from ubuntu-core-launcher to snap-run by
     providing both commands as binary packages, with proper dependencies and
     post-installation scripts that manage apparmor profile changes.
+  * Discard the useless duplicate argument. Now snap-run is invoked with
+    'snap-name $SECURITY_TAG $COMMAND...'. Previously, security tag was
+    duplicated. In the future this will change once again, so that security
+    tag is derived from an argument containing $SNAP_NAME and $APP_NAME. 
 
  -- Zygmunt Krynicki <zygmunt.krynicki@canonical.com>  Sun, 22 May 2016 16:14:24 +0300
 

--- a/src/main.c
+++ b/src/main.c
@@ -478,13 +478,13 @@ void setup_user_data()
 
 int main(int argc, char **argv)
 {
-	const int NR_ARGS = 3;
+	const int NR_ARGS = 2;
 	if (argc < NR_ARGS + 1)
-		die("Usage: %s <appname> <apparmor> <binary>", argv[0]);
+		die("Usage: %s <appname> <security-tag> <binary>", argv[0]);
 
 	const char *appname = argv[1];
-	const char *aa_profile = argv[2];
-	const char *binary = argv[3];
+	const char *aa_profile = argv[1];
+	const char *binary = argv[2];
 	uid_t real_uid = getuid();
 	gid_t real_gid = getgid();
 

--- a/src/main.c
+++ b/src/main.c
@@ -480,7 +480,7 @@ int main(int argc, char **argv)
 {
 	const int NR_ARGS = 2;
 	if (argc < NR_ARGS + 1)
-		die("Usage: %s <appname> <security-tag> <binary>", argv[0]);
+		die("Usage: %s <security-tag> <binary>", argv[0]);
 
 	const char *appname = argv[1];
 	const char *aa_profile = argv[1];

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-
-L=$(pwd)/../src/snap-run
+    
+L="$(pwd)/../src/snap-run"
 
 TMP="$(mktemp -d)"
 trap "rm -rf $TMP" EXIT

--- a/tests/test_bad_seccomp_filter_length
+++ b/tests/test_bad_seccomp_filter_length
@@ -6,12 +6,12 @@ set -e
 
 printf "Test seccomp filter (bad - too long)"
 
-cat >$TMP/myprofile <<EOF
+cat >$TMP/snap.name.app <<EOF
 # some comment
 baddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 EOF
 
-if $L snap.name.app myprofile /bin/true 2>/dev/null; then
+if $L snap.name.app /bin/true 2>/dev/null; then
     # true returned successfully, length test failed
     FAIL
 fi

--- a/tests/test_bad_seccomp_filter_missing_trailing_newline
+++ b/tests/test_bad_seccomp_filter_missing_trailing_newline
@@ -6,9 +6,9 @@ set -e
 
 printf "Test seccomp filter (bad - no trailing newline)"
 
-echo -n "missingnewline" > $TMP/myprofile
+echo -n "missingnewline" > $TMP/snap.name.app
 
-if $L snap.name.app myprofile /bin/true 2>/dev/null; then
+if $L snap.name.app /bin/true 2>/dev/null; then
     # true returned successfully, length test failed
     FAIL
 fi

--- a/tests/test_complain
+++ b/tests/test_complain
@@ -4,13 +4,13 @@ set -e
 
 . $(pwd)/common.sh
 
-cat >$TMP/myprofile <<EOF
+cat >$TMP/snap.name.app <<EOF
 # some comment
 @complain
 EOF
 
 printf "Test that the @complain keyword works"
-if $L snap.name.app myprofile /bin/ls / >/dev/null; then
+if $L snap.name.app /bin/ls / >/dev/null; then
     PASS
 else
     FAIL

--- a/tests/test_complain_missed
+++ b/tests/test_complain_missed
@@ -4,7 +4,7 @@ set -e
 
 . $(pwd)/common.sh
 
-cat >$TMP/myprofile <<EOF
+cat >$TMP/snap.name.app <<EOF
 # super strict filter
 @complai
 @complaim
@@ -17,7 +17,7 @@ EOF
 # filtering
 
 printf "Test that near misses of complain fail"
-if $L snap.name.app myprofile /bin/true 2>/dev/null; then
+if $L snap.name.app /bin/true 2>/dev/null; then
     # true returned successfully, our filtering is broken!
     FAIL
 else

--- a/tests/test_create_user_data
+++ b/tests/test_create_user_data
@@ -4,12 +4,12 @@ set -e
 
 . $(pwd)/common.sh
 
-cat >$TMP/unrestricted <<EOF
+cat >$TMP/snap.name.app-unrestricted <<EOF
 # some comment
 @unrestricted
 EOF
 
-cat >$TMP/restricted <<EOF
+cat >$TMP/snap.name.app-restricted <<EOF
 # filter that works ok for true
 open
 close
@@ -37,11 +37,11 @@ i-dont-exit
 EOF
 
 # $1: Path to check existence for and potentially remove at the end
-# $2: Profile name
+# $2: either 'restricted' or 'unrestricted'
 # $3: True if success is expected, false otherwise
 run_launcher() {
    pass=false
-   if $L snap.name.app $2 /bin/true 2>/dev/null; then
+   if $L snap.name.app-$2 /bin/true 2>/dev/null; then
       if $3; then
          if [ ! -d "$1" ]; then
             pass=false
@@ -83,27 +83,56 @@ run_current() {
 }
 
 printf "Test that an unrestricted launcher creates user data"
-run_current $TMP/user_data unrestricted true
+if run_current $TMP/user_data unrestricted true; then
+   PASS
+else
+   FAIL
+fi
 
 printf "Test that a restricted launcher creates user data"
-run_current $TMP/user_data restricted true
+if run_current $TMP/user_data restricted true; then
+    PASS
+else
+    FAIL
+fi
 
 printf "Test that an unrestricted launcher creates user data with parent directory"
-run_current $TMP/parent/user_data unrestricted true
+if run_current $TMP/parent/user_data unrestricted true; then
+    PASS
+else
+    FAIL
+fi
 
 printf "Test that a restricted launcher creates user data with parent directory"
-run_current $TMP/parent/user_data restricted true
+if run_current $TMP/parent/user_data restricted true; then
+    PASS
+else
+    FAIL
+fi
 
 printf "Test that user data can contain multiple path separators"
-run_current $TMP//user_data unrestricted true
+if run_current $TMP//user_data unrestricted true; then
+    PASS
+else
+    FAIL
+fi
 
 printf "Test that user data must be absolute"
-run_current "../foo" unrestricted false
+if run_current "../foo" unrestricted false; then
+    PASS
+else
+    FAIL
+fi
 
 printf "Testing that user data cannot be contained within a symlink"
 mkdir $TMP/nefarious_parent
 ln -s $TMP/nefarious_parent $TMP/parent
-run_current $TMP/parent/user_data unrestricted, false
+# NOTE: the comma below is significant
+if run_current $TMP/parent/user_data unrestricted, false; then
+    PASS
+else
+    FAIL
+fi
 
 printf "Test that an unrestricted launcher works when user data exists (current)"
 mkdir $TMP/user_data

--- a/tests/test_noprofile
+++ b/tests/test_noprofile
@@ -5,7 +5,7 @@ set -e
 . $(pwd)/common.sh
 
 printf "Test that a non-existing profile causes the launcher to not start"
-if ! $L snap.name.app no-such-profile  /bin/ls >$TMP/testlog 2>&1 ; then
+if ! $L snap.name.app /bin/ls >$TMP/testlog 2>&1 ; then
    PASS
 else
    FAIL

--- a/tests/test_restrictions
+++ b/tests/test_restrictions
@@ -4,7 +4,7 @@ set -e
 
 . $(pwd)/common.sh
 
-cat >$TMP/myprofile <<EOF
+cat >$TMP/snap.name.app <<EOF
 # super strict filter
 EOF
 
@@ -12,7 +12,7 @@ EOF
 # filtering
 
 printf "Test that seccomp filtering kills processes"
-if $L snap.name.app myprofile /bin/true 2>/dev/null; then
+if $L snap.name.app /bin/true 2>/dev/null; then
     # true returned successfully, our filtering is broken!
     FAIL
 else

--- a/tests/test_restrictions_working
+++ b/tests/test_restrictions_working
@@ -4,7 +4,7 @@ set -e
 
 . $(pwd)/common.sh
 
-cat >$TMP/myprofile <<EOF
+cat >$TMP/snap.name.app <<EOF
 # filter that works ok for true
 open
 close
@@ -35,7 +35,7 @@ EOF
 # ensure that the command "true" can run with the right filter
 
 printf "Test that good whitelist"
-if $L snap.name.app myprofile /bin/true 2>/dev/null; then
+if $L snap.name.app /bin/true 2>/dev/null; then
    PASS
 else
     dmesg|tail -n1

--- a/tests/test_unrestricted
+++ b/tests/test_unrestricted
@@ -4,13 +4,13 @@ set -e
 
 . $(pwd)/common.sh
 
-cat >$TMP/myprofile <<EOF
+cat >$TMP/snap.name.app <<EOF
 # some comment
 @unrestricted
 EOF
 
 printf "Test that the @unrestricted keyword works"
-if $L snap.name.app myprofile /bin/ls / >/dev/null; then
+if $L snap.name.app /bin/ls / >/dev/null; then
     PASS
 else
     FAIL

--- a/tests/test_unrestricted_missed
+++ b/tests/test_unrestricted_missed
@@ -4,7 +4,7 @@ set -e
 
 . $(pwd)/common.sh
 
-cat >$TMP/myprofile <<EOF
+cat >$TMP/snap.name.app <<EOF
 # super strict filter
 @unrestricte
 @unrestrictes
@@ -17,7 +17,7 @@ EOF
 # filtering
 
 printf "Test that near misses of unrestricted fail"
-if $L snap.name.app myprofile /bin/true 2>/dev/null; then
+if $L snap.name.app /bin/true 2>/dev/null; then
     # true returned successfully, our filtering is broken!
     FAIL
 else

--- a/tests/test_whitelist
+++ b/tests/test_whitelist
@@ -6,7 +6,7 @@ set -e
 
 printf "Test appname whitelist"
 
-cat >$TMP/myprofile <<EOF
+cat >$TMP/snap.name.app <<EOF
 # some comment
 @unrestricted
 EOF
@@ -14,7 +14,7 @@ EOF
 # good
 for name in snap.name.app snap.network-manager.NetworkManager snap.f00.bar-baz1 ; do
     echo -n "Test good appname whitelist - '$name'"
-    if $L snap.name.app myprofile /bin/true ; then
+    if $L snap.name.app /bin/true ; then
         PASS
     else
         FAIL
@@ -23,7 +23,7 @@ done
 
 for name in pkg-foo.bar.0binary-bar+baz pkg-foo_bar_1.1 appname/.. snap snap. snap.name. snap.name.app. snap!name.app snap.name!app sna.pname.app snap.n@me.app SNAP.name.app snap.Name.app snap.0name.app snap.-name.app snap.name.@app .name.app snap..name.app snap.name..app snap.name.app.. ; do
     echo -n "Test bad appname whitelist - '$name'"
-    if $L $name myprofile /bin/true 2>/dev/null; then
+    if $L $name /bin/true 2>/dev/null; then
         FAIL
     else
         PASS
@@ -31,7 +31,7 @@ for name in pkg-foo.bar.0binary-bar+baz pkg-foo_bar_1.1 appname/.. snap snap. sn
 done
 
 echo -n "Test bad appname whitelist - 'appname space'"
-if $L 'appname space' myprofile /bin/true 2>/dev/null; then
+if $L 'appname space' /bin/true 2>/dev/null; then
     # true returned successfully, our appname whitelist is broken!
     FAIL
 else


### PR DESCRIPTION
Now snap-run is invoked with 'snap-name $SECURITY_TAG $COMMAND...'.
Previously, security tag was duplicated. In the future this will change
once again, so that security tag is derived from an argument containing
$SNAP_NAME and $APP_NAME.
