### PR TITLE
allow to run /usr/lib/snapd/snap-exec

### DIFF
--- a/debian/usr.bin.snap-run
+++ b/debian/usr.bin.snap-run
@@ -18,7 +18,7 @@
     /lib/@{multiarch}/libseccomp.so* mr,
 
     /usr/bin/snap-run r,
-    /usr/lib/snapd/snap-launch mr,
+    /usr/lib/snapd/snap-exec ixr,
 
     /dev/null rw,
     /dev/full rw,

--- a/debian/usr.bin.ubuntu-core-launcher
+++ b/debian/usr.bin.ubuntu-core-launcher
@@ -19,6 +19,9 @@
 
     /usr/bin/ubuntu-core-launcher r,
 
+    # for snap run
+    /usr/bin/snap r,
+
     /dev/null rw,
     /dev/full rw,
     /dev/zero rw,

--- a/debian/usr.bin.ubuntu-core-launcher
+++ b/debian/usr.bin.ubuntu-core-launcher
@@ -18,10 +18,7 @@
     /lib/@{multiarch}/libseccomp.so* mr,
 
     /usr/bin/ubuntu-core-launcher r,
-
-    # for snap run
-    /usr/bin/snap mr,
-    /lib/@{multiarch}/linux-vdso.so* mr,
+    /usr/lib/snapd/snap-launch mr,
 
     /dev/null rw,
     /dev/full rw,

--- a/debian/usr.bin.ubuntu-core-launcher
+++ b/debian/usr.bin.ubuntu-core-launcher
@@ -20,7 +20,8 @@
     /usr/bin/ubuntu-core-launcher r,
 
     # for snap run
-    /usr/bin/snap r,
+    /usr/bin/snap mr,
+    /lib/@{multiarch}/linux-vdso.so* mr,
 
     /dev/null rw,
     /dev/full rw,


### PR DESCRIPTION
Prepare for moving to `snap run`. Note that this is not good enough yet, I get:

```
/usr/bin/snap: error while loading shared libraries: cannot apply additional memory protection after relocation: Permission denied
```

when trying to run /usr/bin/snap from within the launcher confinement.

The idea is that the wrapper will look like this:
`exec snap run command`

Then `snap run` will  do:
-  all the things it needs to do without confinement (get revision, setup SNAP_USER_DATA_DIR, potentially ask the daemon to refresf confinment etc).
- exec `ubuntu-core-launcher` (snap-run) with `snap run --after-suid-setup`
- snap run --after-suid-setup will parse the snap yaml (confined), will setup the environment including LD_LIBRARY_PATH and all the environment that we currently setup in the launcher
- exec the actual binary.
