### PR TITLE
Fix prototype for seccomp_load_filters

### DIFF
--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -29,6 +29,7 @@
 
 #include <seccomp.h>
 
+#include "seccomp.h"
 #include "utils.h"
 
 #define SC_MAX_LINE_LENGTH	82	// 80 + '\n' + '\0'

--- a/src/seccomp.h
+++ b/src/seccomp.h
@@ -19,6 +19,6 @@
 #ifndef CORE_LAUNCHER_SECCOMP_H
 #define CORE_LAUNCHER_SECCOMP_H
 
-int seccomp_load_filters(const char *filter_profile);
+void seccomp_load_filters(const char *filter_profile);
 
 #endif


### PR DESCRIPTION
This patch fixes previously unnoticed discrepancy between the prototype and definition of `seccomp_load_ilters()` 

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
