### PR TITLE
Add --disable-confinement configure option

### DIFF
--- a/PORTING
+++ b/PORTING
@@ -1,0 +1,15 @@
+Welcome brave porters!
+
+This file is intended to guide you towards porting snappy (comprised of snapd
+and this project, snap-confine) to work on a new kernel. The confinement setup by
+snap-confine has several requirements on the kernel.
+
+TODO: list required patches (apparmor, seccomp)
+TODO: list required kernel configufation
+TODO: list minimum supported kernel version
+
+While you are working on porting those patches to your kernel of choice, you
+may configure snap-confine with --disable-security. This switch drops
+requirement on apparmor, seccomp and udev and reduces snap-confine to arrange
+the filesystem in a correct way for snaps to operate without really confining
+them in any way.

--- a/configure.ac
+++ b/configure.ac
@@ -45,13 +45,11 @@ AC_ARG_ENABLE([confinement],
     esac], [enable_confinement=yes])
 AM_CONDITIONAL([STRICT_CONFINEMENT], [test "x$enable_confinement" = "xyes"])
 
-# Check for required external libraries
-PKG_CHECK_MODULES([UDEV], [libudev])
-PKG_CHECK_MODULES([SECCOMP], [libseccomp])
-
-# Check for apparmor when confinement in enabled.
+# Check for required external libraries when confinement is enabled.
 AS_IF([test "x$enable_confinement" = "xyes"], [
     PKG_CHECK_MODULES([APPARMOR], [libapparmor])
+    PKG_CHECK_MODULES([SECCOMP], [libseccomp])
+    PKG_CHECK_MODULES([UDEV], [libudev])
     AC_DEFINE([STRICT_CONFINEMENT], [1],
         [Define if strict apparmor confinement is available])
 ], [

--- a/configure.ac
+++ b/configure.ac
@@ -32,10 +32,36 @@ AC_FUNC_FORK
 AC_FUNC_STRNLEN
 AC_CHECK_FUNCS([mkdir regcomp setenv strdup strerror])
 
+# Allow to build without confinement by calling:
+# ./configure --disable-confinement
+# This makes it possible to run snaps in devmode on almost any host,
+# regardless of the kernel version.
+AC_ARG_ENABLE([confinement],
+    AS_HELP_STRING([--disable-confinement], [Disable strict confinement]),
+    [case "${enableval}" in
+        yes) enable_confinement=yes ;;
+        no)  enable_confinement=no ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --disable-confinement])
+    esac], [enable_confinement=yes])
+AM_CONDITIONAL([STRICT_CONFINEMENT], [test "x$enable_confinement" = "xyes"])
+
 # Check for required external libraries
 PKG_CHECK_MODULES([UDEV], [libudev])
 PKG_CHECK_MODULES([SECCOMP], [libseccomp])
-PKG_CHECK_MODULES([APPARMOR], [libapparmor])
+
+# Check for apparmor when confinement in enabled.
+AS_IF([test "x$enable_confinement" = "xyes"], [
+    PKG_CHECK_MODULES([APPARMOR], [libapparmor])
+    AC_DEFINE([STRICT_CONFINEMENT], [1],
+        [Define if strict apparmor confinement is available])
+], [
+    AC_MSG_WARN([
+    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    X                                                     X
+    X Confinement disabled, all snaps will run in devmode X
+    X                                                     X
+    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX])
+])
 
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,12 +4,15 @@ snap_confine_CFLAGS = \
     -Wall -Werror \
     $(AM_CFLAGS) \
     $(SECCOMP_CFLAGS) \
-    $(APPARMOR_CFLAGS) \
     $(UDEV_CFLAGS)
 snap_confine_LDADD = \
     $(SECCOMP_LIBS) \
-    $(APPARMOR_LIBS) \
     $(UDEV_LIBS)
+
+if STRICT_CONFINEMENT
+snap_run_CFLAGS += $(APPARMOR_CFLAGS)
+snap_run_LDADD += $(APPARMOR_LIBS)
+endif
 
 # Force particular coding style on all source and header files.
 .PHONY: check-syntax

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,17 +1,12 @@
 bin_PROGRAMS = snap-confine
-snap_confine_SOURCES = main.c seccomp_utils.c utils.c
-snap_confine_CFLAGS = \
-    -Wall -Werror \
-    $(AM_CFLAGS) \
-    $(SECCOMP_CFLAGS) \
-    $(UDEV_CFLAGS)
-snap_confine_LDADD = \
-    $(SECCOMP_LIBS) \
-    $(UDEV_LIBS)
+snap_confine_SOURCES = main.c utils.c
+snap_confine_CFLAGS = -Wall -Werror
+snap_confine_LDADD =
 
 if STRICT_CONFINEMENT
-snap_run_CFLAGS += $(APPARMOR_CFLAGS)
-snap_run_LDADD += $(APPARMOR_LIBS)
+snap_confine_SOURCES += seccomp_utils.c
+snap_confine_CFLAGS += $(APPARMOR_CFLAGS) $(SECCOMP_CFLAGS) $(UDEV_CFLAGS)
+snap_confine_LDADD += $(APPARMOR_LIBS) $(SECCOMP_LIBS) $(UDEV_LIBS)
 endif
 
 # Force particular coding style on all source and header files.
@@ -37,6 +32,7 @@ fmt:
 	       indent -linux "$$f"; \
 	done;
 
+if STRICT_CONFINEMENT
 # Install udev rules
 install-data-local:
 	install -d -m 755 $(DESTDIR)/lib/udev/rules.d
@@ -46,6 +42,7 @@ install-data-local:
 install-exec-local:
 	install -d -m 755 $(DESTDIR)/lib/udev
 	install -m 755 snappy-app-dev $(DESTDIR)/lib/udev/
+endif
 
 # Ensure that snap-confine is +s (setuid)
 install-exec-hook:

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,9 @@
 #include <limits.h>
 #include <linux/sched.h>
 #include <sys/mount.h>
+#ifdef STRICT_CONFINEMENT
 #include <sys/apparmor.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -43,6 +45,8 @@
 
 #include "utils.h"
 #include "seccomp_utils.h"
+
+#include "config.h"
 
 #define MAX_BUF 1000
 
@@ -545,6 +549,7 @@ int main(int argc, char **argv)
 
 	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
 
+#ifdef STRICT_CONFINEMENT
 	int rc = 0;
 	// set apparmor rules
 	rc = aa_change_onexec(aa_profile);
@@ -552,6 +557,7 @@ int main(int argc, char **argv)
 		if (secure_getenv("SNAPPY_LAUNCHER_INSIDE_TESTS") == NULL)
 			die("aa_change_onexec failed with %i", rc);
 	}
+#endif
 	// set seccomp (note: seccomp_load_filters die()s on all failures)
 	seccomp_load_filters(aa_profile);
 

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,8 @@
 #define _GNU_SOURCE
 #endif
 
+#include "config.h"
+
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,8 +47,6 @@
 
 #include "utils.h"
 #include "seccomp_utils.h"
-
-#include "config.h"
 
 #define MAX_BUF 1000
 


### PR DESCRIPTION
This patch adds a configure option to disable strict confinement. With this
option selected apparmor is no longer a dependency and snap-run can be used
anywhere, regardless of the kernel patches or availability of apparmor, as long
snaps are used in devmode.

Signed-off-by: Zygmunt Krynicki zkrynicki@gmail.com
