### PR TITLE
Move the lintian overrides to the new package name

### DIFF
--- a/debian/snap-confine.lintian-overrides
+++ b/debian/snap-confine.lintian-overrides
@@ -1,0 +1,2 @@
+# Yes, we expect this to be suid.
+snap-confine: setuid-binary usr/bin/snap-confine 4755 root/root

--- a/debian/snap-run.lintian-overrides
+++ b/debian/snap-run.lintian-overrides
@@ -1,2 +1,0 @@
-# Yes, we expect this to be suid.
-snap-run: setuid-binary usr/bin/snap-run 4755 root/root


### PR DESCRIPTION
snap-run was renamed to snap-confine before the lintian overrides landed, move them now
