### PR TITLE
Improve autotools distribution support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,19 @@
 src/snap-confine
-src/tmp
+
+# Automake
+Makefile
+Makefile.in
+snap-confine-*.tar.gz
+
+# Autoconf
+aclocal.m4
+autom4te.cache
+compile
+config.guess
+config.h.in
+config.sub
+configure
+depcomp
+install-sh
+missing
+test-driver

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,2 @@
 SUBDIRS = src tests compat
+EXTRA_DIST = PORTING README.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = src tests
+SUBDIRS = src tests compat

--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -1,0 +1,1 @@
+dist_bin_SCRIPTS = ubuntu-core-launcher

--- a/configure.ac
+++ b/configure.ac
@@ -61,5 +61,5 @@ AS_IF([test "x$enable_confinement" = "xyes"], [
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX])
 ])
 
-AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile compat/Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,6 +32,8 @@ fmt:
 	       indent -linux "$$f"; \
 	done;
 
+EXTRA_DIST = 80-snappy-assign.rules snappy-app-dev
+
 if STRICT_CONFINEMENT
 # Install udev rules
 install-data-local:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
 bin_PROGRAMS = snap-confine
-snap_confine_SOURCES = main.c utils.c
+snap_confine_SOURCES = main.c utils.c utils.h
 snap_confine_CFLAGS = -Wall -Werror
 snap_confine_LDADD =
 
 if STRICT_CONFINEMENT
-snap_confine_SOURCES += seccomp_utils.c
+snap_confine_SOURCES += seccomp_utils.c seccomp_utils.h
 snap_confine_CFLAGS += $(APPARMOR_CFLAGS) $(SECCOMP_CFLAGS) $(UDEV_CFLAGS)
 snap_confine_LDADD += $(APPARMOR_LIBS) $(SECCOMP_LIBS) $(UDEV_LIBS)
 endif


### PR DESCRIPTION
This branch fixes various issues I've found while trying to use `make dist` - missing header files, missing support files, etc. I've also added git ignore rules for all the things that are built or provided by autotools.
