### PR TITLE
Build compatiblity script to not hardcode $(libdir)

### DIFF
--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -1,1 +1,6 @@
 dist_bin_SCRIPTS = ubuntu-core-launcher
+CLEANFILES = $(dist_bin_SCRIPTS)
+
+ubuntu-core-launcher: ubuntu-core-launcher.in
+	sed -e 's,[@]LIBDIR[@],$(libdir),g' < $(srcdir)/ubuntu-core-launcher.in > ubuntu-core-launcher
+	chmod +x ubuntu-core-launcher

--- a/compat/ubuntu-core-launcher
+++ b/compat/ubuntu-core-launcher
@@ -1,3 +1,0 @@
-#!/bin/sh
-shift
-exec /usr/lib/snap-confine "$@"

--- a/compat/ubuntu-core-launcher.in
+++ b/compat/ubuntu-core-launcher.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+shift
+exec @LIBDIR@/snap-confine "$@"


### PR DESCRIPTION
Since $(libdir) is configurable it should not be hard-coded as /usr/lib anywhere, including the compatibility script.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
