### PR TITLE
Split udev functions to dedicated module

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,19 @@
 bin_PROGRAMS = snap-confine
-snap_confine_SOURCES = main.c utils.c utils.h
+snap_confine_SOURCES = \
+	main.c \
+	utils.c \
+	utils.h \
+	snap.c \
+	snap.h
 snap_confine_CFLAGS = -Wall -Werror
 snap_confine_LDADD =
 
 if STRICT_CONFINEMENT
-snap_confine_SOURCES += seccomp_utils.c seccomp_utils.h
+snap_confine_SOURCES += \
+	seccomp_utils.c \
+	seccomp_utils.h \
+	udev-support.c \
+	udev-support.h
 snap_confine_CFLAGS += $(APPARMOR_CFLAGS) $(SECCOMP_CFLAGS) $(UDEV_CFLAGS)
 snap_confine_LDADD += $(APPARMOR_LIBS) $(SECCOMP_LIBS) $(UDEV_LIBS)
 endif

--- a/src/main.c
+++ b/src/main.c
@@ -14,250 +14,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
 #include "config.h"
 
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
-#include <linux/sched.h>
 #include <sys/mount.h>
 #ifdef STRICT_CONFINEMENT
 #include <sys/apparmor.h>
 #endif				// ifdef STRICT_CONFINEMENT
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 #include <errno.h>
 #include <sched.h>
 #include <string.h>
-#include <linux/kdev_t.h>
-#include <stdlib.h>
-#include <regex.h>
-#include <grp.h>
 #include <fcntl.h>
 
-#include <ctype.h>
-
 #include "utils.h"
+#include "snap.h"
 #ifdef STRICT_CONFINEMENT
-#include "libudev.h"
 #include "seccomp_utils.h"
-#endif				// ifdef STRICT_CONFINEMENT
-
-#define MAX_BUF 1000
-
-#ifdef STRICT_CONFINEMENT
-struct snappy_udev {
-	struct udev *udev;
-	struct udev_enumerate *devices;
-	struct udev_list_entry *assigned;
-	char tagname[MAX_BUF];
-	size_t tagname_len;
-};
-#endif				// ifdef STRICT_CONFINEMENT
-
-bool verify_appname(const char *appname)
-{
-	// snappy appname is of form:
-	// snap.<name>.<app>
-	// - <name> must start with lowercase letter, then may contain
-	//   lowercase alphanumerics and '-'
-	// - <app> may contain alphanumerics and '-'
-	const char *whitelist_re = "^snap\\.[a-z][a-z0-9-]*\\.[a-zA-Z0-9-]+$";
-	regex_t re;
-	if (regcomp(&re, whitelist_re, REG_EXTENDED | REG_NOSUB) != 0)
-		die("can not compile regex %s", whitelist_re);
-
-	int status = regexec(&re, appname, 0, NULL, 0);
-	regfree(&re);
-
-	return (status == 0);
-}
-
-#ifdef STRICT_CONFINEMENT
-void run_snappy_app_dev_add(struct snappy_udev *udev_s, const char *path)
-{
-	if (udev_s == NULL)
-		die("snappy_udev is NULL");
-	if (udev_s->udev == NULL)
-		die("snappy_udev->udev is NULL");
-	if (udev_s->tagname_len == 0
-	    || udev_s->tagname_len >= MAX_BUF
-	    || strnlen(udev_s->tagname, MAX_BUF) != udev_s->tagname_len
-	    || udev_s->tagname[udev_s->tagname_len] != '\0')
-		die("snappy_udev->tagname has invalid length");
-
-	debug("%s: %s %s", __func__, path, udev_s->tagname);
-
-	struct udev_device *d =
-	    udev_device_new_from_syspath(udev_s->udev, path);
-	if (d == NULL)
-		die("can not find %s", path);
-	dev_t devnum = udev_device_get_devnum(d);
-	udev_device_unref(d);
-
-	int status = 0;
-	pid_t pid = fork();
-	if (pid < 0) {
-		die("could not fork");
-	}
-	if (pid == 0) {
-		uid_t real_uid, effective_uid, saved_uid;
-		if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0)
-			die("could not find user IDs");
-		// can't update the cgroup unless the real_uid is 0, euid as
-		// 0 is not enough
-		if (real_uid != 0 && effective_uid == 0)
-			if (setuid(0) != 0)
-				die("setuid failed");
-		char buf[64];
-		unsigned major = MAJOR(devnum);
-		unsigned minor = MINOR(devnum);
-		must_snprintf(buf, sizeof(buf), "%u:%u", major, minor);
-		execl("/lib/udev/snappy-app-dev", "/lib/udev/snappy-app-dev",
-		      "add", udev_s->tagname, path, buf, NULL);
-		die("execl failed");
-	}
-	if (waitpid(pid, &status, 0) < 0)
-		die("waitpid failed");
-	if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
-		die("child exited with status %i", WEXITSTATUS(status));
-	else if (WIFSIGNALED(status))
-		die("child died with signal %i", WTERMSIG(status));
-}
-
-/*
- * snappy_udev_init() - setup the snappy_udev structure. Return 0 if devices
- * are assigned, else return -1. Callers should use snappy_udev_cleanup() to
- * cleanup.
- */
-int snappy_udev_init(const char *appname, struct snappy_udev *udev_s)
-{
-	debug("%s", __func__);
-	int rc = 0;
-
-	// extra paranoia
-	if (!verify_appname(appname))
-		die("appname %s not allowed", appname);
-
-	udev_s->tagname[0] = '\0';
-	udev_s->tagname_len = 0;
-	// TAG+="snap_<appname>" (udev doesn't like '.' in the tag name)
-	udev_s->tagname_len = must_snprintf(udev_s->tagname, MAX_BUF,
-					    "%s", appname);
-	for (int i = 0; i < udev_s->tagname_len; i++)
-		if (udev_s->tagname[i] == '.')
-			udev_s->tagname[i] = '_';
-
-	udev_s->udev = udev_new();
-	if (udev_s->udev == NULL)
-		die("udev_new failed");
-
-	udev_s->devices = udev_enumerate_new(udev_s->udev);
-	if (udev_s->devices == NULL)
-		die("udev_enumerate_new failed");
-
-	if (udev_enumerate_add_match_tag(udev_s->devices, udev_s->tagname) != 0)
-		die("udev_enumerate_add_match_tag");
-
-	if (udev_enumerate_scan_devices(udev_s->devices) != 0)
-		die("udev_enumerate_scan failed");
-
-	udev_s->assigned = udev_enumerate_get_list_entry(udev_s->devices);
-	if (udev_s->assigned == NULL)
-		rc = -1;
-
-	return rc;
-}
-
-void snappy_udev_cleanup(struct snappy_udev *udev_s)
-{
-	// udev_s->assigned does not need to be unreferenced since it is a
-	// pointer into udev_s->devices
-	if (udev_s->devices != NULL)
-		udev_enumerate_unref(udev_s->devices);
-	if (udev_s->udev != NULL)
-		udev_unref(udev_s->udev);
-}
-
-void setup_devices_cgroup(const char *appname, struct snappy_udev *udev_s)
-{
-	debug("%s", __func__);
-	// Devices that must always be present
-	const char *static_devices[] = {
-		"/sys/class/mem/null",
-		"/sys/class/mem/full",
-		"/sys/class/mem/zero",
-		"/sys/class/mem/random",
-		"/sys/class/mem/urandom",
-		"/sys/class/tty/tty",
-		"/sys/class/tty/console",
-		"/sys/class/tty/ptmx",
-		NULL,
-	};
-
-	// extra paranoia
-	if (!verify_appname(appname))
-		die("appname %s not allowed", appname);
-	if (udev_s == NULL)
-		die("snappy_udev is NULL");
-	if (udev_s->udev == NULL)
-		die("snappy_udev->udev is NULL");
-	if (udev_s->devices == NULL)
-		die("snappy_udev->devices is NULL");
-	if (udev_s->assigned == NULL)
-		die("snappy_udev->assigned is NULL");
-	if (udev_s->tagname_len == 0
-	    || udev_s->tagname_len >= MAX_BUF
-	    || strnlen(udev_s->tagname, MAX_BUF) != udev_s->tagname_len
-	    || udev_s->tagname[udev_s->tagname_len] != '\0')
-		die("snappy_udev->tagname has invalid length");
-
-	// create devices cgroup controller
-	char cgroup_dir[PATH_MAX];
-
-	must_snprintf(cgroup_dir, sizeof(cgroup_dir),
-		      "/sys/fs/cgroup/devices/%s/", appname);
-
-	if (mkdir(cgroup_dir, 0755) < 0 && errno != EEXIST)
-		die("mkdir failed");
-
-	// move ourselves into it
-	char cgroup_file[PATH_MAX];
-	must_snprintf(cgroup_file, sizeof(cgroup_file), "%s%s", cgroup_dir,
-		      "tasks");
-
-	char buf[128];
-	must_snprintf(buf, sizeof(buf), "%i", getpid());
-	write_string_to_file(cgroup_file, buf);
-
-	// deny by default. Write 'a' to devices.deny to remove all existing
-	// devices that were added in previous launcher invocations, then add
-	// the static and assigned devices. This ensures that at application
-	// launch the cgroup only has what is currently assigned.
-	must_snprintf(cgroup_file, sizeof(cgroup_file), "%s%s", cgroup_dir,
-		      "devices.deny");
-	write_string_to_file(cgroup_file, "a");
-
-	// add the common devices
-	for (int i = 0; static_devices[i] != NULL; i++)
-		run_snappy_app_dev_add(udev_s, static_devices[i]);
-
-	// add the assigned devices
-	while (udev_s->assigned != NULL) {
-		const char *path = udev_list_entry_get_name(udev_s->assigned);
-		if (path == NULL)
-			die("udev_list_entry_get_name failed");
-		run_snappy_app_dev_add(udev_s, path);
-		udev_s->assigned = udev_list_entry_get_next(udev_s->assigned);
-	}
-}
-
+#include "udev-support.h"
 #endif				// ifdef STRICT_CONFINEMENT
 
 bool is_running_on_classic_distribution()

--- a/src/snap.c
+++ b/src/snap.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+#include "snap.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <regex.h>
+
+#include "utils.h"
+
+bool verify_appname(const char *appname)
+{
+	// snappy appname is of form:
+	// snap.<name>.<app>
+	// - <name> must start with lowercase letter, then may contain
+	//   lowercase alphanumerics and '-'
+	// - <app> may contain alphanumerics and '-'
+	const char *whitelist_re = "^snap\\.[a-z][a-z0-9-]*\\.[a-zA-Z0-9-]+$";
+	regex_t re;
+	if (regcomp(&re, whitelist_re, REG_EXTENDED | REG_NOSUB) != 0)
+		die("can not compile regex %s", whitelist_re);
+
+	int status = regexec(&re, appname, 0, NULL, 0);
+	regfree(&re);
+
+	return (status == 0);
+}

--- a/src/snap.h
+++ b/src/snap.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_SNAP_H
+#define SNAP_CONFINE_SNAP_H
+
+#include <stdbool.h>
+
+bool verify_appname(const char *appname);
+
+#endif

--- a/src/udev-support.c
+++ b/src/udev-support.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2015-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+#include "udev-support.h"
+
+#include <unistd.h>
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <sched.h>
+#include <string.h>
+#include <linux/kdev_t.h>
+
+#include <ctype.h>
+
+#include "utils.h"
+#include "snap.h"
+
+void run_snappy_app_dev_add(struct snappy_udev *udev_s, const char *path)
+{
+	if (udev_s == NULL)
+		die("snappy_udev is NULL");
+	if (udev_s->udev == NULL)
+		die("snappy_udev->udev is NULL");
+	if (udev_s->tagname_len == 0
+	    || udev_s->tagname_len >= MAX_BUF
+	    || strnlen(udev_s->tagname, MAX_BUF) != udev_s->tagname_len
+	    || udev_s->tagname[udev_s->tagname_len] != '\0')
+		die("snappy_udev->tagname has invalid length");
+
+	debug("%s: %s %s", __func__, path, udev_s->tagname);
+
+	struct udev_device *d =
+	    udev_device_new_from_syspath(udev_s->udev, path);
+	if (d == NULL)
+		die("can not find %s", path);
+	dev_t devnum = udev_device_get_devnum(d);
+	udev_device_unref(d);
+
+	int status = 0;
+	pid_t pid = fork();
+	if (pid < 0) {
+		die("could not fork");
+	}
+	if (pid == 0) {
+		uid_t real_uid, effective_uid, saved_uid;
+		if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0)
+			die("could not find user IDs");
+		// can't update the cgroup unless the real_uid is 0, euid as
+		// 0 is not enough
+		if (real_uid != 0 && effective_uid == 0)
+			if (setuid(0) != 0)
+				die("setuid failed");
+		char buf[64];
+		unsigned major = MAJOR(devnum);
+		unsigned minor = MINOR(devnum);
+		must_snprintf(buf, sizeof(buf), "%u:%u", major, minor);
+		execl("/lib/udev/snappy-app-dev", "/lib/udev/snappy-app-dev",
+		      "add", udev_s->tagname, path, buf, NULL);
+		die("execl failed");
+	}
+	if (waitpid(pid, &status, 0) < 0)
+		die("waitpid failed");
+	if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
+		die("child exited with status %i", WEXITSTATUS(status));
+	else if (WIFSIGNALED(status))
+		die("child died with signal %i", WTERMSIG(status));
+}
+
+/*
+ * snappy_udev_init() - setup the snappy_udev structure. Return 0 if devices
+ * are assigned, else return -1. Callers should use snappy_udev_cleanup() to
+ * cleanup.
+ */
+int snappy_udev_init(const char *appname, struct snappy_udev *udev_s)
+{
+	debug("%s", __func__);
+	int rc = 0;
+
+	// extra paranoia
+	if (!verify_appname(appname))
+		die("appname %s not allowed", appname);
+
+	udev_s->tagname[0] = '\0';
+	udev_s->tagname_len = 0;
+	// TAG+="snap_<appname>" (udev doesn't like '.' in the tag name)
+	udev_s->tagname_len = must_snprintf(udev_s->tagname, MAX_BUF,
+					    "%s", appname);
+	for (int i = 0; i < udev_s->tagname_len; i++)
+		if (udev_s->tagname[i] == '.')
+			udev_s->tagname[i] = '_';
+
+	udev_s->udev = udev_new();
+	if (udev_s->udev == NULL)
+		die("udev_new failed");
+
+	udev_s->devices = udev_enumerate_new(udev_s->udev);
+	if (udev_s->devices == NULL)
+		die("udev_enumerate_new failed");
+
+	if (udev_enumerate_add_match_tag(udev_s->devices, udev_s->tagname) != 0)
+		die("udev_enumerate_add_match_tag");
+
+	if (udev_enumerate_scan_devices(udev_s->devices) != 0)
+		die("udev_enumerate_scan failed");
+
+	udev_s->assigned = udev_enumerate_get_list_entry(udev_s->devices);
+	if (udev_s->assigned == NULL)
+		rc = -1;
+
+	return rc;
+}
+
+void snappy_udev_cleanup(struct snappy_udev *udev_s)
+{
+	// udev_s->assigned does not need to be unreferenced since it is a
+	// pointer into udev_s->devices
+	if (udev_s->devices != NULL)
+		udev_enumerate_unref(udev_s->devices);
+	if (udev_s->udev != NULL)
+		udev_unref(udev_s->udev);
+}
+
+void setup_devices_cgroup(const char *appname, struct snappy_udev *udev_s)
+{
+	debug("%s", __func__);
+	// Devices that must always be present
+	const char *static_devices[] = {
+		"/sys/class/mem/null",
+		"/sys/class/mem/full",
+		"/sys/class/mem/zero",
+		"/sys/class/mem/random",
+		"/sys/class/mem/urandom",
+		"/sys/class/tty/tty",
+		"/sys/class/tty/console",
+		"/sys/class/tty/ptmx",
+		NULL,
+	};
+
+	// extra paranoia
+	if (!verify_appname(appname))
+		die("appname %s not allowed", appname);
+	if (udev_s == NULL)
+		die("snappy_udev is NULL");
+	if (udev_s->udev == NULL)
+		die("snappy_udev->udev is NULL");
+	if (udev_s->devices == NULL)
+		die("snappy_udev->devices is NULL");
+	if (udev_s->assigned == NULL)
+		die("snappy_udev->assigned is NULL");
+	if (udev_s->tagname_len == 0
+	    || udev_s->tagname_len >= MAX_BUF
+	    || strnlen(udev_s->tagname, MAX_BUF) != udev_s->tagname_len
+	    || udev_s->tagname[udev_s->tagname_len] != '\0')
+		die("snappy_udev->tagname has invalid length");
+
+	// create devices cgroup controller
+	char cgroup_dir[PATH_MAX];
+
+	must_snprintf(cgroup_dir, sizeof(cgroup_dir),
+		      "/sys/fs/cgroup/devices/%s/", appname);
+
+	if (mkdir(cgroup_dir, 0755) < 0 && errno != EEXIST)
+		die("mkdir failed");
+
+	// move ourselves into it
+	char cgroup_file[PATH_MAX];
+	must_snprintf(cgroup_file, sizeof(cgroup_file), "%s%s", cgroup_dir,
+		      "tasks");
+
+	char buf[128];
+	must_snprintf(buf, sizeof(buf), "%i", getpid());
+	write_string_to_file(cgroup_file, buf);
+
+	// deny by default. Write 'a' to devices.deny to remove all existing
+	// devices that were added in previous launcher invocations, then add
+	// the static and assigned devices. This ensures that at application
+	// launch the cgroup only has what is currently assigned.
+	must_snprintf(cgroup_file, sizeof(cgroup_file), "%s%s", cgroup_dir,
+		      "devices.deny");
+	write_string_to_file(cgroup_file, "a");
+
+	// add the common devices
+	for (int i = 0; static_devices[i] != NULL; i++)
+		run_snappy_app_dev_add(udev_s, static_devices[i]);
+
+	// add the assigned devices
+	while (udev_s->assigned != NULL) {
+		const char *path = udev_list_entry_get_name(udev_s->assigned);
+		if (path == NULL)
+			die("udev_list_entry_get_name failed");
+		run_snappy_app_dev_add(udev_s, path);
+		udev_s->assigned = udev_list_entry_get_next(udev_s->assigned);
+	}
+}

--- a/src/udev-support.h
+++ b/src/udev-support.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_UDEV_SUPPORT_H
+#define SNAP_CONFINE_UDEV_SUPPORT_H
+
+#include <stddef.h>
+
+#include <libudev.h>
+
+#define MAX_BUF 1000
+
+struct snappy_udev {
+	struct udev *udev;
+	struct udev_enumerate *devices;
+	struct udev_list_entry *assigned;
+	char tagname[MAX_BUF];
+	size_t tagname_len;
+};
+
+void run_snappy_app_dev_add(struct snappy_udev *udev_s, const char *path);
+int snappy_udev_init(const char *appname, struct snappy_udev *udev_s);
+void snappy_udev_cleanup(struct snappy_udev *udev_s);
+void setup_devices_cgroup(const char *appname, struct snappy_udev *udev_s);
+
+#endif


### PR DESCRIPTION
This patch moves existing udev related functions to src/udev-support.[ch].
While doing this I realized I also need to move verify_appname() so for the
lack of a better place I moved it to src/snap.[ch].

I plan to move more functions out of main, to the point where each of the
support modules has an API for doing one thing it is responsible for and other
functions can be static.

Signed-off-by: Zygmunt Krynicki zkrynicki@gmail.com
