### PR TITLE
Add configuration option for using core snap as rootfs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,5 +61,24 @@ AS_IF([test "x$enable_confinement" = "xyes"], [
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX])
 ])
 
+# Allow to use the new execution environment based on pivot_root and bind-mount
+# of the core snap. This is closer to how an all-snap system would execute
+# applications (the root file system is a read only core snap) and is more
+# flexible in how the host OS can look like (it can have any directory layout)
+# and lastly it is much easier to implement arbitrary bind mounts from the
+# classic environment.
+AC_ARG_ENABLE([rootfs_is_core_snap],
+    AS_HELP_STRING([--enable-rootfs-is-core-snap], [Use core snap as the root file system]),
+    [case "${enableval}" in
+        yes) enable_rootfs_is_core_snap=yes ;;
+        no)  enable_rootfs_is_core_snap=no ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-rootfs-is-core-snap])
+    esac], [enable_rootfs_is_core_snap=no])
+AM_CONDITIONAL([ROOTFS_IS_CORE_SNAP], [test "x$enable_rootfs_is_core_snap" = "xyes"])
+
+AS_IF([test "x$enable_rootfs_is_core_snap" = "xyes"], [
+    AC_DEFINE([ROOTFS_IS_CORE_SNAP], [1],
+        [Use the core snap as the root file system])])
+
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile compat/Makefile])
 AC_OUTPUT

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -127,7 +127,9 @@ void setup_private_pts()
 void setup_snappy_os_mounts()
 {
 	debug("%s", __func__);
-
+#ifdef ROOTFS_IS_CORE_SNAP
+#error "not implemented"
+#else
 	// we mount some whitelisted directories
 	//
 	// Note that we do not mount "/etc/" from snappy. We could do that,
@@ -159,6 +161,7 @@ void setup_snappy_os_mounts()
 			die("unable to bind %s to %s", src, dst);
 		}
 	}
+#endif				// ROOTFS_IS_CORE_SNAP
 }
 
 void setup_slave_mount_namespace()


### PR DESCRIPTION
This patch adds --enable-rootfs-is-core-snap configure-time option which will
shortly allow to use the core snap as the root filesystem.

Signed-off-by: Zygmunt Krynicki zkrynicki@gmail.com
