### PR TITLE
chdir() to '/' before setting up private /tmp (LP: #1592402)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -33,7 +33,8 @@ ubuntu-core-launcher (1.0.29) UNRELEASED; urgency=medium
   [ Jamie Strandboge ]
   * debian/usr.bin.snap-confine: allow access to ecryptfs lower files
     (LP: #1574556, LP: #1592696)
-  * chdir() to '/' before setting up private /tmp (LP: #1592402)
+  * chdir() to '/' before setting up private /tmp so private /tmp works when
+    user is in /tmp (LP: #1592402)
 
  -- Zygmunt Krynicki <zygmunt.krynicki@canonical.com>  Sun, 22 May 2016 16:14:24 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -30,6 +30,9 @@ ubuntu-core-launcher (1.0.29) UNRELEASED; urgency=medium
   * Enable hardening options for snap-confine
   * Build-depend on udev, use udevlibdir instead of hardcoding /lib/udev
 
+  [ Jamie Strandboge ]
+  * chdir() to '/' before setting up private /tmp (LP: #1592402)
+
  -- Zygmunt Krynicki <zygmunt.krynicki@canonical.com>  Sun, 22 May 2016 16:14:24 +0300
 
 ubuntu-core-launcher (1.0.28) yakkety; urgency=medium

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -69,6 +69,13 @@ void setup_private_mount(const char *appname)
 	}
 	umask(old_mask);
 
+	// chdir to '/' since the mount won't apply to the current directory
+	char *pwd = get_current_dir_name();
+	if (pwd == NULL)
+		die("unable to get current directory");
+	if (chdir("/") != 0)
+		die("unable to change directory to '/'");
+
 	// MS_BIND is there from linux 2.4
 	if (mount(tmpdir, "/tmp", NULL, MS_BIND, NULL) != 0) {
 		die("unable to bind private /tmp");
@@ -81,6 +88,11 @@ void setup_private_mount(const char *appname)
 	if (chown("/tmp/", uid, gid) < 0) {
 		die("unable to chown tmpdir");
 	}
+	// chdir to original directory
+	if (chdir(pwd) != 0)
+		die("unable to change to original directory");
+	free(pwd);
+
 	// ensure we set the various TMPDIRs to our newly created tmpdir
 	const char *tmpd[] = { "TMPDIR", "TEMPDIR", NULL };
 	int i;


### PR DESCRIPTION
chdir() to '/' before setting up private /tmp so private /tmp works when user is in /tmp (LP: #1592402)
