### PR TITLE
Constrain tests to x86_64/amd64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,7 @@ AC_ARG_ENABLE([confinement],
         *) AC_MSG_ERROR([bad value ${enableval} for --disable-confinement])
     esac], [enable_confinement=yes])
 AM_CONDITIONAL([STRICT_CONFINEMENT], [test "x$enable_confinement" = "xyes"])
+AM_CONDITIONAL([CONFINEMENT_TESTS], [test "x$enable_confinement" = "xyes" && test "x$host_cpu" = "xx86_64" && test "x$build_cpu" = "xx86_64"])
 
 # Check for required external libraries when confinement is enabled.
 AS_IF([test "x$enable_confinement" = "xyes"], [

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,7 +15,9 @@ all_tests = \
 EXTRA_DIST = $(all_tests) common.sh
 
 if STRICT_CONFINEMENT
+if CONFINEMENT_TESTS
 TESTS += $(all_tests)
+endif
 endif
 
 check: ../src/snap-confine


### PR DESCRIPTION
This patch changes tests so that they are only ran on amd64. Tests are
somewhat syscall specific and on some architectures they cause false
alarms today. Before this is fixed they should be constrained.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
