### PR TITLE
Try to preserve current working directory

### DIFF
--- a/spread-tests/regression/lp-1595444/task.yaml
+++ b/spread-tests/regression/lp-1595444/task.yaml
@@ -1,0 +1,15 @@
+summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1595444
+# This is blacklisted on debian because we first have to get the dpkg-vendor patches
+systems: [-debian-8]
+execute: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap list | grep -q snapd-hacker-toolbelt || snap install snapd-hacker-toolbelt
+
+    echo "We can go to a location that is available in all snaps (/tmp)"
+    echo "We can run the 'cwd' tool from busybox and it reports /tmp" 
+    [ "$(cd /tmp && /snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "/tmp" ]
+
+    echo "But if we go to a location that is not available to snaps (e.g. $HOME/.cache)"
+    echo "Then the same 'cwd' tool reports the root directory instead"
+    mkdir -p $HOME/.cache/
+    [ "$(cd $HOME/.cache && /snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "/" ]

--- a/spread-tests/regression/lp-1595444/task.yaml
+++ b/spread-tests/regression/lp-1595444/task.yaml
@@ -10,6 +10,12 @@ execute: |
     [ "$(cd /tmp && /snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "/tmp" ]
 
     echo "But if we go to a location that is not available to snaps (e.g. $HOME/.cache)"
-    echo "Then the same 'cwd' tool reports the root directory instead"
-    mkdir -p $HOME/.cache/
-    [ "$(cd $HOME/.cache && /snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "/" ]
+    echo "Then the same 'cwd' tool refuses to run the snap"
+    mkdir -p "$HOME/.cache/"
+    cd "$HOME/.cache" || exit 1
+    # pwd doesn't run
+    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "" ]
+    # there's an accurate error message
+    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox pwd 2>&1)" = "cannot remain in $HOME/.cache, please run this snap from another location" ]
+    # snap-confine returns an error code on exit
+    ! /snap/bin/snapd-hacker-toolbelt.busybox pwd

--- a/spread-tests/regression/lp-1595444/task.yaml
+++ b/spread-tests/regression/lp-1595444/task.yaml
@@ -16,6 +16,6 @@ execute: |
     # pwd doesn't run
     [ "$(/snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "" ]
     # there's an accurate error message
-    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox pwd 2>&1)" = "cannot remain in $HOME/.cache, please run this snap from another location" ]
+    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox pwd 2>&1)" = "cannot remain in $HOME/.cache, please run this snap from another location. errmsg: No such file or directory" ]
     # snap-confine returns an error code on exit
     ! /snap/bin/snapd-hacker-toolbelt.busybox pwd

--- a/spread.yaml
+++ b/spread.yaml
@@ -19,7 +19,6 @@ prepare: |
     echo "Spread is running as $(id)"
     [ "$REUSE_PROJECT" != 1 ] || exit 0
     release_ID="$( . /etc/os-release && echo "${ID:-linux}" )"
-
     case $release_ID in
         ubuntu)
             # apt update is hanging on security.ubuntu.com with IPv6.
@@ -27,13 +26,14 @@ prepare: |
             trap "sysctl -w net.ipv6.conf.all.disable_ipv6=0" EXIT
             ;;
         debian)
+            echo "deb http://ftp.de.debian.org/debian sid main" > /etc/apt/sources.list.d/snappy.list
             ;;
     esac
     case $release_ID in
         ubuntu|debian)
-            apt-get purge -y snap-confine || true
             apt-get update
             apt-get install --quiet -y fakeroot
+            # Build a local copy of snap-confine
             apt-get install --quiet -y autoconf automake autotools-dev debhelper dh-apparmor dh-autoreconf indent libapparmor-dev libseccomp-dev libudev-dev pkg-config shellcheck udev
             test -d /home/test || adduser --quiet --disabled-password --gecos '' test
             chown test.test -R ..
@@ -41,8 +41,15 @@ prepare: |
             dpkg -i ../snap-confine_*.deb || apt-get -f install -y
             dpkg -i ../ubuntu-core-launcher_*.deb || apt-get -f install -y
             rm -f ../snap-confine_*.deb ../ubuntu-core-launcher_*.deb
+            # Install snapd (testes require it)
+            apt-get install -y snapd
             ;;
     esac
+    # Install the core snap
+    snap list | grep -q ubuntu-core || snap install ubuntu-core
+
 suites:
     spread-tests/:
         summary: Full-system tests for snap-confine 
+    spread-tests/regression/:
+        summary: Regression tests for past bug-fixes

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,7 +10,9 @@ snap_confine_SOURCES = \
 	mount-support.c \
 	mount-support.h \
 	mount-support-nvidia.c \
-	mount-support-nvidia.h
+	mount-support-nvidia.h \
+	cleanup-funcs.c \
+	cleanup-funcs.h
 snap_confine_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_confine_LDFLAGS = $(AM_LDFLAGS)
 snap_confine_LDADD =

--- a/src/cleanup-funcs.c
+++ b/src/cleanup-funcs.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdlib.h>
+
+void sc_cleanup_string(char **ptr)
+{
+	free(*ptr);
+}

--- a/src/cleanup-funcs.h
+++ b/src/cleanup-funcs.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_CLEANUP_FUNCS_H
+#define SNAP_CONFINE_CLEANUP_FUNCS_H
+
+/**
+ * Free a dynamically allocated string.
+ *
+ * This function is designed to be used with
+ * __attribute__((cleanup(sc_cleanup_string))).
+ **/
+void sc_cleanup_string(char **ptr);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -116,7 +116,11 @@ int main(int argc, char **argv)
 		// diagnostic message and carry on without failing.
 		if (chdir(vanilla_cwd) != 0) {
 			fprintf(stderr,
-				"cannot remain in the original working directory\n");
+				"cannot remain in directory %s, changing to root directory instead\n",
+				vanilla_cwd);
+			if (chdir("/") != 0) {
+				die("cannot change directory to /");
+			}
 		}
 		// the rest does not so temporarily drop privs back to calling
 		// user (we'll permanently drop after loading seccomp)

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@
 #include "seccomp-support.h"
 #include "udev-support.h"
 #endif				// ifdef STRICT_CONFINEMENT
+#include "cleanup-funcs.h"
 
 int main(int argc, char **argv)
 {
@@ -89,8 +90,10 @@ int main(int argc, char **argv)
 		// Get the current working directory before we start fiddling with
 		// mounts and possibly pivot_root.  At the end of the whole process, we
 		// will try to re-locate to the same directory (if possible).
-		char vanilla_cwd[512];
-		if (getcwd(vanilla_cwd, sizeof vanilla_cwd) == NULL) {
+		char *vanilla_cwd __attribute__ ((cleanup(sc_cleanup_string))) =
+		    NULL;
+		vanilla_cwd = get_current_dir_name();
+		if (vanilla_cwd == NULL) {
 			die("cannot get the current working directory");
 		}
 		// do the mounting if run on a non-native snappy system

--- a/src/main.c
+++ b/src/main.c
@@ -112,15 +112,13 @@ int main(int argc, char **argv)
 #endif				// ifdef STRICT_CONFINEMENT
 
 		// Try to re-locate back to vanilla working directory. This can fail
-		// because that directory is no longer present. In that case print a
-		// diagnostic message and carry on without failing.
+		// because that directory is no longer present.
 		if (chdir(vanilla_cwd) != 0) {
+			// NOTE: Use exit rather than die as this produces a more refined error message
 			fprintf(stderr,
-				"cannot remain in directory %s, changing to root directory instead\n",
+				"cannot remain in %s, please run this snap from another location\n",
 				vanilla_cwd);
-			if (chdir("/") != 0) {
-				die("cannot change directory to /");
-			}
+			exit(1);
 		}
 		// the rest does not so temporarily drop privs back to calling
 		// user (we'll permanently drop after loading seccomp)

--- a/src/main.c
+++ b/src/main.c
@@ -114,11 +114,7 @@ int main(int argc, char **argv)
 		// Try to re-locate back to vanilla working directory. This can fail
 		// because that directory is no longer present.
 		if (chdir(vanilla_cwd) != 0) {
-			// NOTE: Use exit rather than die as this produces a more refined error message
-			fprintf(stderr,
-				"cannot remain in %s, please run this snap from another location\n",
-				vanilla_cwd);
-			exit(1);
+			die("cannot remain in %s, please run this snap from another location", vanilla_cwd);
 		}
 		// the rest does not so temporarily drop privs back to calling
 		// user (we'll permanently drop after loading seccomp)

--- a/src/mount-support-nvidia.c
+++ b/src/mount-support-nvidia.c
@@ -78,11 +78,6 @@ static const char *nvidia_globs[] = {
 static const size_t nvidia_globs_len =
     sizeof nvidia_globs / sizeof *nvidia_globs;
 
-static void cleanup_string(char **ptr)
-{
-	free(*ptr);
-}
-
 // Populate libgl_dir with a symlink farm to files matching glob_list.
 //
 // The symbolic links are made in one of two ways. If the library found is a
@@ -113,7 +108,8 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 		char symlink_name[512];
 		char symlink_target[512];
 		const char *pathname = glob_res.gl_pathv[i];
-		char *pathname_copy __attribute__ ((cleanup(cleanup_string))) =
+		char *pathname_copy
+		    __attribute__ ((cleanup(sc_cleanup_string))) =
 		    strdup(pathname);
 		char *filename = basename(pathname_copy);
 		struct stat stat_buf;


### PR DESCRIPTION
This patch makes snap-confine save and then try to restore the current
working directory. In the past this was not done and the working
directory was always reset to the root directory, making snaps of
command like tools like git or spread useless.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1595444
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
