### PR TITLE
Add a manual page for snap-confine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ install-sh
 missing
 stamp-h1
 test-driver
+
+# manual pages
+docs/*.[1-9]

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,2 @@
-SUBDIRS = src tests
+SUBDIRS = src tests docs
 EXTRA_DIST = PORTING README.md

--- a/configure.ac
+++ b/configure.ac
@@ -110,5 +110,5 @@ AS_IF([test "x$enable_nvidia_arch" = "xyes"], [
     AC_DEFINE([NVIDIA_ARCH], [1],
         [Support for propietary nvidia drivers (Arch)])])
 
-AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile docs/Makefile])
 AC_OUTPUT

--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,9 @@ ubuntu-core-launcher (1.0.33) UNRELEASED; urgency=medium
   [ Jamie Strandboge ]
   * implement seccomp argument filtering (LP: #1446748)
 
+  [ Zygmunt Krynicki ]
+  * Build-depend on python3-docutils for rst2man
+
  -- Zygmunt Krynicki <zygmunt.krynicki@canonical.com>  Sun, 19 Jun 2016 00:46:10 +0200
 
 ubuntu-core-launcher (1.0.30) yakkety; urgency=medium

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends: autoconf,
                libseccomp-dev,
                libudev-dev,
                pkg-config,
+               python3-docutils,
                shellcheck,
                udev
 Standards-Version: 3.9.8

--- a/debian/snap-confine.manpages
+++ b/debian/snap-confine.manpages
@@ -1,0 +1,1 @@
+debian/tmp/usr/share/man/man5/snap-confine.5

--- a/debian/ubuntu-core-launcher.manpages
+++ b/debian/ubuntu-core-launcher.manpages
@@ -1,0 +1,1 @@
+debian/tmp/usr/share/man/man1/ubuntu-core-launcher.1

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,0 +1,10 @@
+dist_man_MANS = snap-confine.5 ubuntu-core-launcher.1
+
+CLEANFILES = snap-confine.5 ubuntu-core-launcher.1
+EXTRA_DIST = snap-confine.rst ubuntu-core-launcher.rst
+
+snap-confine.5: snap-confine.rst
+	rst2man $^ > $@
+
+ubuntu-core-launcher.1: ubuntu-core-launcher.rst
+	rst2man $^ > $@

--- a/docs/snap-confine.rst
+++ b/docs/snap-confine.rst
@@ -1,0 +1,117 @@
+==============
+ snap-confine
+==============
+
+-----------------------------------------------
+internal tool for confining snappy applications
+-----------------------------------------------
+
+:Author: zygmunt.krynicki@canonical.com
+:Date:   2016-06-27
+:Copyright: Canonical Ltd.
+:Version: 1.0.33
+:Manual section: 5
+:Manual group: snappy
+
+SYNOPSIS
+========
+
+	snap-confine SECURITY_TAG COMMAND [...ARGUMENTS]
+
+DESCRIPTION
+===========
+
+The `snap-confine` is a program used internally by `snapd` to construct a
+confined execution environment for snap applications.
+
+OPTIONS
+=======
+
+The `snap-confine` program does not support any options.
+
+FEATURES
+========
+
+Apparmor profiles
+-----------------
+
+`snap-confine` switches to the apparmor profile `$SECURITY_TAG`. The profile is
+**mandatory** and `snap-confine` will refuse to run without it.
+
+has to be loaded into the kernel prior to using `snap-confine`. Typically this
+is arranged for by `snapd`. The profile contains rich description of what the
+application process is allowed to do, this includes system calls, file paths,
+access patterns, linux capabilities, etc. The apparmor profile can also do
+extensive dbus mediation. Refer to apparmor documentation for more details.
+
+Seccomp profiles
+----------------
+
+`snap-confine` looks for the `/var/lib/snapd/seccomp/profiles/$SECURITY_TAG`
+file. This file is **mandatory** and `snap-confine` will refuse to run without
+it.
+
+The file is read and parsed using a custom syntax that describes the set of
+allowed system calls and optionally their arguments. The profile is then used
+to confine the started application. 
+
+As a security precaution disallowed system calls cause the started application
+executable to be killed by the kernel. In the future this restriction may be
+lifted to return `EPERM` instead.
+
+Mount profiles
+--------------
+
+`snap-confine` looks for the `/var/lib/snapd/mount/$SECURITY_TAG.fstab` file.
+If present it is read, parsed and treated like a typical `fstab(5)` file.
+The mount directives listed there are executed in order. All directives must
+succeed as any failure will abort execution.
+
+By default all mount entries start with the following flags: `bind`, `ro`,
+`nodev`, `nosuid`.  Some of those flags can be reversed by an appropriate
+option (e.g. `rw` can cause the mount point to be writable).
+
+As a security precaution only `bind` mounts are supported at this time.
+
+ENVIRONMENT
+===========
+
+`snap-confine` responds to the following environment variables
+
+`UBUNTU_CORE_LAUNCHER_DEBUG`:
+	When defined the program will print additional diagnostic information about
+	the actions being performed. All the output goes to stderr.
+
+The following variables are only used when `snap-confine` is not setuid root.
+This is only applicable when testing the program itself.
+
+`SNAPPY_LAUNCHER_INSIDE_TESTS`:
+	Internal variable that should not be relied upon.
+
+`UBUNTU_CORE_LAUNCHER_NO_ROOT`:
+	Internal variable that should not be relied upon.
+
+`SNAPPY_LAUNCHER_SECCOMP_PROFILE_DIR`:
+	Internal variable that should not be relied upon.
+
+FILES
+=====
+
+`snap-confine` uses the following files:
+
+`/var/lib/snapd/mount/*.fstab`:
+
+	Description of the mount profile.
+
+`/var/lib/snapd/seccomp/profiles/*`:
+
+	Description of the seccomp profile.
+
+Note that the apparmor profile is external to `snap-confine` and is loaded
+directly into the kernel. The actual apparmor profile is managed by `snapd`.
+
+BUGS
+====
+
+Please report all bugs with https://bugs.launchpad.net/snap-confine/+filebug
+

--- a/docs/ubuntu-core-launcher.rst
+++ b/docs/ubuntu-core-launcher.rst
@@ -1,0 +1,40 @@
+======================
+ ubuntu-core-launcher
+======================
+
+-----------------------------------------------
+internal tool for confining snappy applications
+-----------------------------------------------
+
+:Author: zygmunt.krynicki@canonical.com
+:Date:   2016-06-27
+:Copyright: Canonical Ltd.
+:Version: 1.0.33
+:Manual section: 1
+:Manual group: snappy
+
+SYNOPSIS
+========
+
+	ubuntu-core-launcher SECURITY_TAG SECURITY_TAG COMMAND [...ARGUMENTS]
+
+DESCRIPTION
+===========
+
+This program is a thin wrapper around `snap-confine`. Please do not rely on it,
+it is likely to be removed in the next release.
+
+OPTIONS
+=======
+
+The `ubuntu-core-launcher` program does not support any options.
+
+BUGS
+====
+
+Please report all bugs with https://bugs.launchpad.net/snap-confine/+filebug
+
+SEE ALSO
+========
+
+`snap-confine(5)`

--- a/spread.yaml
+++ b/spread.yaml
@@ -34,7 +34,7 @@ prepare: |
             apt-get update
             apt-get install --quiet -y fakeroot
             # Build a local copy of snap-confine
-            apt-get install --quiet -y autoconf automake autotools-dev debhelper dh-apparmor dh-autoreconf indent libapparmor-dev libseccomp-dev libudev-dev pkg-config shellcheck udev
+            apt-get install --quiet -y autoconf automake autotools-dev debhelper dh-apparmor dh-autoreconf indent libapparmor-dev libseccomp-dev libudev-dev pkg-config shellcheck udev python3-docutils
             test -d /home/test || adduser --quiet --disabled-password --gecos '' test
             chown test.test -R ..
             sudo -i -u test /bin/sh -c "cd $PWD && DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -tc -b -Zgzip"


### PR DESCRIPTION
While snap-confine is not typically exposed on PATH, having a manual
page will help to demystify some of the things happening inside.

I plan to land this small version an then expand it with more details
about how the execution environment looks like.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
