### PR TITLE
Install udev rules even if confinement isn't enabled

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,7 +57,6 @@ fmt:
 
 EXTRA_DIST = 80-snappy-assign.rules snappy-app-dev
 
-if STRICT_CONFINEMENT
 # NOTE: This makes distcheck fail but it is required for udev, so go figure.
 # http://www.gnu.org/software/automake/manual/automake.html#Hard_002dCoded-Install-Paths
 #
@@ -70,7 +69,6 @@ install-data-local:
 install-exec-local:
 	install -d -m 755 $(DESTDIR)$(shell pkg-config udev --variable=udevdir)
 	install -m 755 $(srcdir)/snappy-app-dev $(DESTDIR)$(shell pkg-config udev --variable=udevdir)
-endif
 
 # Ensure that snap-confine is +s (setuid)
 install-exec-hook:


### PR DESCRIPTION
Even if confinement is not enabled in snapd, it's safe to install the udev rule
and the udev helper which simply will never match any tags.  Installing these
means we can avoid special-casing of the packaging on different Debian-based
distributions.

(this is the patch that is currently in debian sid)
