### PR TITLE
Rename sanity tests to unit tests

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,8 +34,8 @@ snap_confine_LDADD += $(APPARMOR_LIBS) $(SECCOMP_LIBS) $(LIBUDEV_LIBS)
 endif
 
 sanity_test_SOURCES = \
-	sanity.c \
-	sanity.h \
+	unit-tests.c \
+	unit-tests.h \
 	$(snap_confine_SOURCES)
 # Comple sanity-tests from the same sources as snap-confine but
 # define the _SANITY_TESTING macro so that test code can be

--- a/src/main.c
+++ b/src/main.c
@@ -34,13 +34,13 @@
 #endif				// ifdef STRICT_CONFINEMENT
 #include "cleanup-funcs.h"
 #ifdef _SANITY_TESTING
-#include "sanity.h"
+#include "unit-tests.h"
 #endif
 
 int main(int argc, char **argv)
 {
 #ifdef _SANITY_TESTING
-	return sc_run_sanity_checks(&argc, &argv);
+	return sc_run_unit_tests(&argc, &argv);
 #else				// _SANITY_TESTING
 	char *basename = strrchr(argv[0], '/');
 	if (basename) {

--- a/src/unit-tests.c
+++ b/src/unit-tests.c
@@ -18,10 +18,7 @@
 #include "config.h"
 #endif
 
-#include "sanity.h"
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/wait.h>
+#include "unit-tests.h"
 #include <glib.h>
 
 static void simple_test_case(void)
@@ -30,7 +27,7 @@ static void simple_test_case(void)
 	g_assert_cmpint(g_bit_storage(1), ==, 1);
 }
 
-int sc_run_sanity_checks(int *argc, char ***argv)
+int sc_run_unit_tests(int *argc, char ***argv)
 {
 	g_test_init(argc, argv, NULL);
 	g_test_add_func("/Simple Test Case", simple_test_case);

--- a/src/unit-tests.h
+++ b/src/unit-tests.h
@@ -15,9 +15,15 @@
  *
  */
 
-#ifndef SNAP_CONFINE_SANITY_H
-#define SNAP_CONFINE_SANITY_H
+#ifndef SNAP_CONFINE_UNIT_TESTS_H
+#define SNAP_CONFINE_UNIT_TESTS_H
 
-int sc_run_sanity_checks(int *argc, char ***argv);
+/**
+ * Run unit tests and exit.
+ *
+ * The function inspects and modifies command line arguments.
+ * Internally it is using glib-test functions.
+ */
+int sc_run_unit_tests(int *argc, char ***argv);
 
 #endif				// SNAP_CONFINE_SANITY_H


### PR DESCRIPTION
This branch is a small follow-up from the sanity-tests branch reviewed by mvo earlier.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
