### PR TITLE
do not use #ifdef but crazy include instead

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,20 +36,19 @@ snap_confine_LDADD += $(APPARMOR_LIBS) $(SECCOMP_LIBS) $(LIBUDEV_LIBS)
 endif
 
 sanity_test_SOURCES = \
+        unit-tests-main.c \
 	unit-tests.c \
 	unit-tests.h \
-	$(snap_confine_SOURCES)
+	utils_test.c \
+	cleanup-funcs_test.c \
+	mount-support_test.c
 # Comple sanity-tests from the same sources as snap-confine but
 # define the _UNIT_TESTING macro so that test code can be
 # included. This lets us put tests right next to actual static
 # functions for better visiblitiy.
-sanity_test_CFLAGS = $(snap_confine_CFLAGS)
-sanity_test_LDADD = $(snap_confine_LDADD)
+sanity_test_CFLAGS = $(snap_confine_CFLAGS) $(GLIB_CFLAGS)
+sanity_test_LDADD = $(snap_confine_LDADD) $(GLIB_LIBS)
 sanity_test_LDFLAGS = $(snap_confine_LDFLAGS)
-sanity_test_CFLAGS += -D_UNIT_TESTING
-# Sanity tests are using glib's testing facilities
-sanity_test_CFLAGS += $(GLIB_CFLAGS)
-sanity_test_LDADD += $(GLIB_LIBS)
 
 # Force particular coding style on all source and header files.
 .PHONY: check-syntax

--- a/src/cleanup-funcs.h
+++ b/src/cleanup-funcs.h
@@ -19,6 +19,7 @@
 #define SNAP_CONFINE_CLEANUP_FUNCS_H
 
 #include <stdlib.h>
+#include <stdio.h>
 
 /**
  * Free a dynamically allocated string.

--- a/src/cleanup-funcs_test.c
+++ b/src/cleanup-funcs_test.c
@@ -1,0 +1,2 @@
+#include "cleanup-funcs.h"
+#include "cleanup-funcs.c"

--- a/src/main.c
+++ b/src/main.c
@@ -14,17 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#ifdef _UNIT_TESTING
-#include "unit-tests.h"
-#else
 #include "sc-main.h"
-#endif
 
 int main(int argc, char **argv)
 {
-#ifdef _UNIT_TESTING
-	return sc_run_unit_tests(&argc, &argv);
-#else				// _UNIT_TESTING
 	return sc_main(argc, argv);
-#endif				// _UNIT_TESTING
 }

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -393,35 +393,3 @@ static char * __attribute__ ((used))
 	return (offset < fulllen) ? &path[offset] : NULL;
 }
 
-#ifdef _UNIT_TESTING
-
-#include <glib.h>
-
-static void test_get_nextpath()
-{
-	char path[] = "/some/path";
-	int offset = 0;
-	int fulllen = strlen(path);
-
-	// Prepare path for useage with get_nextpath() by replacing
-	// all path separators with the NUL byte.
-	for (int i = 0; i < fulllen; i++) {
-		if (path[i] == '/')
-			path[i] = '\0';
-	}
-
-	// Run get_nextpath a few times to see what happens.
-	char *result;
-	result = get_nextpath(path, &offset, fulllen);
-	g_assert_cmpstr(result, ==, "some");
-	result = get_nextpath(path, &offset, fulllen);
-	g_assert_cmpstr(result, ==, "path");
-	result = get_nextpath(path, &offset, fulllen);
-	g_assert_cmpstr(result, ==, NULL);
-}
-
-static void __attribute__ ((constructor)) init()
-{
-	g_test_add_func("/mount/get_nextpath", test_get_nextpath);
-}
-#endif

--- a/src/mount-support_test.c
+++ b/src/mount-support_test.c
@@ -1,0 +1,36 @@
+
+#include "mount-support.h"
+#include "mount-support.c"
+#include "mount-support-nvidia.h"
+#include "mount-support-nvidia.c"
+
+#include <glib.h>
+
+static void test_get_nextpath()
+{
+	char path[] = "/some/path";
+	int offset = 0;
+	int fulllen = strlen(path);
+
+	// Prepare path for useage with get_nextpath() by replacing
+	// all path separators with the NUL byte.
+	for (int i = 0; i < fulllen; i++) {
+		if (path[i] == '/')
+			path[i] = '\0';
+	}
+
+	// Run get_nextpath a few times to see what happens.
+	char *result;
+	result = get_nextpath(path, &offset, fulllen);
+	g_assert_cmpstr(result, ==, "some");
+	result = get_nextpath(path, &offset, fulllen);
+	g_assert_cmpstr(result, ==, "path");
+	result = get_nextpath(path, &offset, fulllen);
+	g_assert_cmpstr(result, ==, NULL);
+}
+
+static void __attribute__ ((constructor)) init()
+{
+	g_test_add_func("/mount/get_nextpath", test_get_nextpath);
+}
+

--- a/src/unit-tests-main.c
+++ b/src/unit-tests-main.c
@@ -14,26 +14,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include <stdlib.h>
-#include <stdbool.h>
+#include "unit-tests.h"
 
-#ifndef CORE_LAUNCHER_UTILS_H
-#define CORE_LAUNCHER_UTILS_H
-
-__attribute__ ((noreturn))
-    __attribute__ ((format(printf, 1, 2)))
-void die(const char *fmt, ...);
-
-__attribute__ ((format(printf, 1, 2)))
-bool error(const char *fmt, ...);
-
-__attribute__ ((format(printf, 1, 2)))
-void debug(const char *fmt, ...);
-
-void write_string_to_file(const char *filepath, const char *buf);
-
-// snprintf version that dies on any error condition
-__attribute__ ((format(printf, 3, 4)))
-int must_snprintf(char *str, size_t size, const char *format, ...);
-
-#endif
+int main(int argc, char **argv)
+{
+	return sc_run_unit_tests(&argc, &argv);
+}

--- a/src/utils_test.c
+++ b/src/utils_test.c
@@ -1,0 +1,2 @@
+#include "utils.h"
+#include "utils.c"


### PR DESCRIPTION
Slightly different way of organizing the tests. This avoids the #ifdef (which I really dislike) and makes it more like go and moving the unit tests into a separate file (using the #include trick to still being able to test static functions).
