### PR TITLE
Packaging updates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-launcher (1.0.33ubuntu1) UNRELEASED; urgency=medium
+
+  * Bring in changes from 1.0.33-1 from debian:
+
+ -- Michael Hudson-Doyle <michael.hudson@ubuntu.com>  Fri, 01 Jul 2016 09:42:00 +1200
+
 ubuntu-core-launcher (1.0.33) UNRELEASED; urgency=medium
 
   [ Zygmunt Krynicki ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
-ubuntu-core-launcher (1.0.33ubuntu1) UNRELEASED; urgency=medium
+snap-confine (1.0.33ubuntu1) UNRELEASED; urgency=medium
 
   * Bring in changes from 1.0.33-1 from debian:
+    - Rename source package to snap-confine.
 
  -- Michael Hudson-Doyle <michael.hudson@ubuntu.com>  Fri, 01 Jul 2016 09:42:00 +1200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ snap-confine (1.0.33ubuntu1) UNRELEASED; urgency=medium
   * Bring in changes from 1.0.33-1 from debian:
     - Rename source package to snap-confine.
     - Add debian/watch for upstream tarballs.
+    - Use dpkg-vendor so that we can use a single debian/rules for both Debian and Ubuntu.
 
  -- Michael Hudson-Doyle <michael.hudson@ubuntu.com>  Fri, 01 Jul 2016 09:42:00 +1200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ snap-confine (1.0.33ubuntu1) UNRELEASED; urgency=medium
 
   * Bring in changes from 1.0.33-1 from debian:
     - Rename source package to snap-confine.
+    - Add debian/watch for upstream tarballs.
 
  -- Michael Hudson-Doyle <michael.hudson@ubuntu.com>  Fri, 01 Jul 2016 09:42:00 +1200
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: ubuntu-core-launcher
+Source: snap-confine
 Section: utils
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>

--- a/debian/rules
+++ b/debian/rules
@@ -3,11 +3,23 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 
+
+# Currently, we enable confinement for Ubuntu only, not for derivatives,
+# because derivatives may have different kernels that don't support all the
+# required confinement features and we don't to mislead anyone about the
+# security of the system.  Discuss a proper approach to this for downstreams
+# if and when they approach us
+ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
+    VENDOR_ARGS=--enable-rootfs-is-core-snap
+else
+    VENDOR_ARGS=--disable-confinement
+endif
+
 %:
 	dh $@ --with autoreconf
 
 override_dh_auto_configure:
-	./configure --enable-nvidia-ubuntu --enable-rootfs-is-core-snap --prefix=/usr --libexecdir=/usr/lib/snapd
+	./configure --enable-nvidia-ubuntu --prefix=/usr --libexecdir=/usr/lib/snapd $(VENDOR_ARGS)
 
 override_dh_fixperms:
 	dh_fixperms -Xusr/lib/snapd/snap-confine

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,3 @@
+version=3
+opts=filenamemangle=s/.+\/snap-confine-(\d\S*)\.tar\.gz/snap-confine-$1\.tar\.gz/ \
+  https://github.com/snapcore/snap-confine/releases/ .*/snap-confine-(\d\S*)\.tar\.gz


### PR DESCRIPTION
Here are some changes that were made to the packaging before the package was uploaded to debian. What to put in debian/changelog was mostly just a guess, not really sure how to represent the mixed up history.

I'm also not sure about what --libexecdir should be -- /usr/lib/snapd or /usr/lib/snap-confine? I've left this unchanged for now.
