### PR TITLE
Control apparmor and seccomp separately

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,37 +32,59 @@ AC_FUNC_FORK
 AC_FUNC_STRNLEN
 AC_CHECK_FUNCS([mkdir regcomp setenv strdup strerror])
 
-# Allow to build without confinement by calling:
-# ./configure --disable-confinement
+# Allow to build without apparmor support by calling:
+# ./configure --disable-apparmor
 # This makes it possible to run snaps in devmode on almost any host,
 # regardless of the kernel version.
-AC_ARG_ENABLE([confinement],
-    AS_HELP_STRING([--disable-confinement], [Disable strict confinement]),
+AC_ARG_ENABLE([apparmor],
+    AS_HELP_STRING([--disable-apparmor], [Disable apparmor support]),
     [case "${enableval}" in
-        yes) enable_confinement=yes ;;
-        no)  enable_confinement=no ;;
-        *) AC_MSG_ERROR([bad value ${enableval} for --disable-confinement])
-    esac], [enable_confinement=yes])
-AM_CONDITIONAL([STRICT_CONFINEMENT], [test "x$enable_confinement" = "xyes"])
-AM_CONDITIONAL([CONFINEMENT_TESTS], [test "x$enable_confinement" = "xyes" && (test "x$host_cpu" = "xx86_64" && test "x$build_cpu" = "xx86_64") || (test "x$host_cpu" = "xi686" && test "x$build_cpu" = "xi686")])
+        yes) enable_apparmor=yes ;;
+        no)  enable_apparmor=no ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --disable-apparmor])
+    esac], [enable_apparmor=yes])
+AM_CONDITIONAL([APPARMOR], [test "x$enable_apparmor" = "xyes"])
 
-# Check for required external libraries when confinement is enabled.
-AS_IF([test "x$enable_confinement" = "xyes"], [
-    PKG_CHECK_MODULES([APPARMOR], [libapparmor])
-    PKG_CHECK_MODULES([SECCOMP], [libseccomp])
-    PKG_CHECK_MODULES([LIBUDEV], [libudev])
-    PKG_CHECK_MODULES([UDEV], [udev])
-    AC_DEFINE([STRICT_CONFINEMENT], [1],
-        [Define if strict apparmor confinement is available])
+# Allow to build without seccomp support by calling:
+# ./configure --disable-seccomp
+# This is separate because seccomp support is generally very good and it
+# provides useful confinement for unsafe system calls.
+AC_ARG_ENABLE([seccomp],
+    AS_HELP_STRING([--disable-seccomp], [Disable seccomp support]),
+    [case "${enableval}" in
+        yes) enable_seccomp=yes ;;
+        no)  enable_seccomp=no ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --disable-seccomp])
+    esac], [enable_seccomp=yes])
+AM_CONDITIONAL([SECCOMP], [test "x$enable_seccomp" = "xyes"])
+
+# Enable older tests only when confinement is enabled and we're building for PC
+# The tests are of smaller value as we port more and more tests to spread.
+AM_CONDITIONAL([CONFINEMENT_TESTS], [test "x$enable_apparmor" = "xyes" && test "x$enable_seccomp" = "xyes" && (test "x$host_cpu" = "xx86_64" && test "x$build_cpu" = "xx86_64") || (test "x$host_cpu" = "xi686" && test "x$build_cpu" = "xi686")])
+
+# Check if seccomp userspace library is available
+AS_IF([test "x$enable_seccomp" = "xyes"], [
+    PKG_CHECK_MODULES([SECCOMP], [libseccomp], [
+      AC_DEFINE([HAVE_SECCOMP], [1], [Build with seccomp support])])
+])
+
+# Check if apparmor userspace library is available.
+AS_IF([test "x$enable_apparmor" = "xyes"], [
+    PKG_CHECK_MODULES([APPARMOR], [libapparmor], [
+      AC_DEFINE([HAVE_APPARMOR], [1], [Build with apparmor support])])
 ], [
     AC_MSG_WARN([
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     X                                                     X
-    X Confinement disabled, all snaps will run in devmode X
+    X Apparmor is disabled, all snaps will run in devmode X
     X                                                     X
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX])
 ])
 
+# Check if udev and libudev are available.
+# Those are now used unconditionally even if apparmor is disabled.
+PKG_CHECK_MODULES([LIBUDEV], [libudev])
+PKG_CHECK_MODULES([UDEV], [udev])
 # Check for glib that we use for unit testing
 PKG_CHECK_MODULES([GLIB], [glib-2.0])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,24 +15,32 @@ snap_confine_SOURCES = \
 	mount-support-nvidia.c \
 	mount-support-nvidia.h \
 	cleanup-funcs.c \
-	cleanup-funcs.h
+	cleanup-funcs.h \
+	udev-support.c \
+	udev-support.h
+
 snap_confine_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_confine_LDFLAGS = $(AM_LDFLAGS)
 snap_confine_LDADD =
+snap_confine_CFLAGS += $(LIBUDEV_CFLAGS)
+snap_confine_LDADD += $(LIBUDEV_LIBS)
 
 # This is here to help fix rpmlint hardening issue.
 # https://en.opensuse.org/openSUSE:Packaging_checks#non-position-independent-executable
 snap_confine_CFLAGS += $(SUID_CFLAGS)
 snap_confine_LDFLAGS += $(SUID_LDFLAGS)
 
-if STRICT_CONFINEMENT
+if SECCOMP
 snap_confine_SOURCES += \
 	seccomp-support.c \
-	seccomp-support.h \
-	udev-support.c \
-	udev-support.h
-snap_confine_CFLAGS += $(APPARMOR_CFLAGS) $(SECCOMP_CFLAGS) $(LIBUDEV_CFLAGS)
-snap_confine_LDADD += $(APPARMOR_LIBS) $(SECCOMP_LIBS) $(LIBUDEV_LIBS)
+	seccomp-support.h
+snap_confine_CFLAGS += $(SECCOMP_CFLAGS)
+snap_confine_LDADD += $(SECCOMP_LIBS)
+endif
+
+if APPARMOR
+snap_confine_CFLAGS += $(APPARMOR_CFLAGS)
+snap_confine_LDADD += $(APPARMOR_LIBS)
 endif
 
 snap_confine_unit_tests_SOURCES = \

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -42,7 +42,6 @@
 
 void setup_private_mount(const char *security_tag)
 {
-#ifdef STRICT_CONFINEMENT
 	uid_t uid = getuid();
 	gid_t gid = getgid();
 	char tmpdir[MAX_BUF] = { 0 };
@@ -103,12 +102,10 @@ void setup_private_mount(const char *security_tag)
 			die("unable to set '%s'", tmpd[i]);
 		}
 	}
-#endif				// ifdef STRICT_CONFINEMENT
 }
 
 void setup_private_pts()
 {
-#ifdef STRICT_CONFINEMENT
 	// See https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
 	//
 	// Ubuntu by default uses devpts 'single-instance' mode where
@@ -140,7 +137,6 @@ void setup_private_pts()
 	if (mount("/dev/pts/ptmx", "/dev/ptmx", "none", MS_BIND, 0)) {
 		die("unable to mount '/dev/pts/ptmx'->'/dev/ptmx'");
 	}
-#endif				// ifdef STRICT_CONFINEMENT
 }
 
 #ifdef NVIDIA_ARCH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,7 +23,7 @@ all_tests = \
 
 EXTRA_DIST = $(all_tests) common.sh
 
-if STRICT_CONFINEMENT
+if SECCOMP
 if CONFINEMENT_TESTS
 TESTS += $(all_tests)
 endif


### PR DESCRIPTION
This patch allows seccomp and apparmor support to be disabled
separately. In practice we can now start enabling seccomp support
where userspace libraries are recent enough.

This doens't bring us out of devmode yet but makes a step towards
that goal. On distributions that both apparmor and seccomp are
not fully available yet the old --disable-confinement is now
spelled as --disable-seccomp --disable-apparmor.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
