### PR TITLE
Fix build error on arch

### DIFF
--- a/src/mount-support-nvidia.c
+++ b/src/mount-support-nvidia.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 
 #include "utils.h"
+#include "cleanup-funcs.h"
 
 #ifdef NVIDIA_ARCH
 


### PR DESCRIPTION
Just a missing include. Arch is not part of the CI just yet.
