### PR TITLE
Fix check for CONFINEMENT_TESTS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ AM_CONDITIONAL([SECCOMP], [test "x$enable_seccomp" = "xyes"])
 
 # Enable older tests only when confinement is enabled and we're building for PC
 # The tests are of smaller value as we port more and more tests to spread.
-AM_CONDITIONAL([CONFINEMENT_TESTS], [test "x$enable_apparmor" = "xyes" && test "x$enable_seccomp" = "xyes" && (test "x$host_cpu" = "xx86_64" && test "x$build_cpu" = "xx86_64") || (test "x$host_cpu" = "xi686" && test "x$build_cpu" = "xi686")])
+AM_CONDITIONAL([CONFINEMENT_TESTS], [test "x$enable_apparmor" = "xyes" && test "x$enable_seccomp" = "xyes" && ((test "x$host_cpu" = "xx86_64" && test "x$build_cpu" = "xx86_64") || (test "x$host_cpu" = "xi686" && test "x$build_cpu" = "xi686"))])
 
 # Check if seccomp userspace library is available
 AS_IF([test "x$enable_seccomp" = "xyes"], [


### PR DESCRIPTION
Without this fix CONFINEMENT_TESTS is always set if you build on i686
