### PR TITLE
use execle() with empty environment when calling snappy-app-dev

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,14 @@ snap-confine (1.0.34) UNRELEASED; urgency=medium
   [ Zygmunt Krynicki ]
   * New upstream release
 
+  [ Jamie Strandboge ]
+  * use execle() with clean environment instead of execl() when calling
+    snappy-add-dev to avoid influencing snappy-add-dev and allowing privilege
+    escalation. snappy-app-dev is only called when devices are assigned via
+    udev tagging, but currently snapd does not create these udev tags during
+    'snap install' or 'snap connect' so this code branch is not entered during
+    app invocation. (LP: #1599608)
+
  -- Michael Hudson-Doyle <michael.hudson@ubuntu.com>  Fri, 01 Jul 2016 09:42:00 +1200
 
 ubuntu-core-launcher (1.0.33) UNRELEASED; urgency=medium

--- a/spread-tests/cgroup-used/task.yaml
+++ b/spread-tests/cgroup-used/task.yaml
@@ -11,7 +11,6 @@ restore: |
     # no way to clear cgroup for hello-world atm
 execute: |
     cd /
-    udevadm settle
     echo Install hello-world
     snap install hello-world
     echo Clear udev tags and cgroups with non-test device and running hello-world
@@ -19,6 +18,7 @@ execute: |
     udevadm control --reload-rules
     udevadm settle
     udevadm trigger
+    udevadm settle
     hello-world.echo | grep Hello
     echo Verify no tags for hello-world.echo for kmsg
     if udevadm info /sys/devices/virtual/mem/kmsg | grep snap_hello-world_echo ; then exit 1; fi

--- a/spread-tests/cgroup-used/task.yaml
+++ b/spread-tests/cgroup-used/task.yaml
@@ -8,7 +8,7 @@ restore: |
     udevadm settle
     udevadm trigger
     udevadm settle
-    # no way to clear cgroups atm
+    # no way to clear cgroup for hello-world atm
 execute: |
     cd /
     udevadm settle

--- a/spread-tests/cgroup-used/task.yaml
+++ b/spread-tests/cgroup-used/task.yaml
@@ -1,0 +1,36 @@
+summary: Check that launcher cgroup functionality works
+# This is blacklisted on debian because we first have to get the dpkg-vendor patches
+systems: [-debian-8]
+restore: |
+    snap remove hello-world
+    rm -f /etc/udev/rules.d/70-spread-test.rules
+    udevadm control --reload-rules
+    udevadm settle
+    udevadm trigger
+    udevadm settle
+    # no way to clear cgroups atm
+execute: |
+    cd /
+    udevadm settle
+    echo Install hello-world
+    snap install hello-world
+    echo Clear udev tags and cgroups with non-test device and running hello-world
+    echo 'KERNEL=="uinput", TAG+="snap_hello-world_echo"' > /etc/udev/rules.d/70-spread-test.rules
+    udevadm control --reload-rules
+    udevadm settle
+    udevadm trigger
+    hello-world.echo | grep Hello
+    echo Verify no tags for hello-world.echo for kmsg
+    if udevadm info /sys/devices/virtual/mem/kmsg | grep snap_hello-world_echo ; then exit 1; fi
+    echo Manually add udev tags for hello-world.echo for kmsg
+    echo 'KERNEL=="kmsg", TAG+="snap_hello-world_echo"' > /etc/udev/rules.d/70-spread-test.rules
+    echo Simulate snapd udev triggers
+    udevadm control --reload-rules
+    udevadm settle
+    udevadm trigger
+    udevadm settle
+    echo Verify udev has tag for kmsg
+    if ! udevadm info /sys/devices/virtual/mem/kmsg | grep snap_hello-world_echo ; then exit 1; fi
+    echo Run hello-world.echo and see if kmsg added to cgroup
+    hello-world.echo | grep Hello
+    if ! grep 'c 1:11 rwm' /sys/fs/cgroup/devices/snap.hello-world.echo/devices.list ; then exit 1; fi

--- a/src/udev-support.c
+++ b/src/udev-support.c
@@ -68,6 +68,9 @@ void run_snappy_app_dev_add(struct snappy_udev *udev_s, const char *path)
 			if (setuid(0) != 0)
 				die("setuid failed");
 		char buf[64];
+		// pass snappy-add-dev an empty environment so the
+		// user-controlled environment can't be used to subvert
+		// snappy-add-dev
 		char *env[] = { NULL };
 		unsigned major = MAJOR(devnum);
 		unsigned minor = MINOR(devnum);

--- a/src/udev-support.c
+++ b/src/udev-support.c
@@ -68,11 +68,12 @@ void run_snappy_app_dev_add(struct snappy_udev *udev_s, const char *path)
 			if (setuid(0) != 0)
 				die("setuid failed");
 		char buf[64];
+		char *env[] = { NULL };
 		unsigned major = MAJOR(devnum);
 		unsigned minor = MINOR(devnum);
 		must_snprintf(buf, sizeof(buf), "%u:%u", major, minor);
-		execl("/lib/udev/snappy-app-dev", "/lib/udev/snappy-app-dev",
-		      "add", udev_s->tagname, path, buf, NULL);
+		execle("/lib/udev/snappy-app-dev", "/lib/udev/snappy-app-dev",
+		       "add", udev_s->tagname, path, buf, NULL, env);
 		die("execl failed");
 	}
 	if (waitpid(pid, &status, 0) < 0)


### PR DESCRIPTION
use execle() with clean environment instead of execl() when calling
snappy-add-dev to avoid influencing snappy-add-dev and allowing privilege
escalation. snappy-app-dev is only called when devices are assigned via udev
tagging, but currently snapd does not create these udev tags during 'snap
install' or 'snap connect' so this code branch is not entered during app
invocation.

Currently this is not a security issue since no snaps will be udev tagged via
snapd (as such, today this can only be exploited by manually creating the
necessary udev tags (and there is no reason or documentation to do so), but
this requires root and is thus not a privilege escalation).

This is a vulnerability in waiting though since whenever the udev tagging is
used and generated by snapd, then an unprivileged user would be able to create
a crafted environment and pass to snappy-app-dev via execl(). While
snappy-app-dev is constrained by the launcher AppArmor profile, clearly this
issue must be addressed.

Thanks to Sebastian Krahmer from SUSE for discovering this issue.
