### PR TITLE
Update apparmor profile for snap-confine

### DIFF
--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -116,13 +116,9 @@
     mount options=(rw bind) /snap/ubuntu-core/*/usr/ -> /usr/,
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /etc/alternatives/,
 
-    # This is a somewhat of a blank check for mount profiles.  Mount profiles
-    # are written by the trusted snapd to a root-writable location and
-    # processed by snap-confine. Regardless of configuration options and
-    # runtime factors they are processed after pivot_root (on classic systems)
-    # so snap.rootfs is not a factor.
-    mount options=(rw bind),
-    mount options=(ro bind),
+    # Allow snaps to share content amongst themselves.
+    mount options=(rw bind) /snap/*/** -> /snap/*/**,
+    mount options=(ro bind) /snap/*/** -> /snap/*/**,
 
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir

--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -71,7 +71,7 @@
 
     # reading seccomp filters
     /{tmp/snap.rootfs_*/,}var/lib/snapd/seccomp/profiles/* r,
- 
+
     # reading mount profiles
     /{tmp/snap.rootfs_*/,}var/lib/snapd/mount/*.fstab r,
 
@@ -121,8 +121,8 @@
     # processed by snap-confine. Regardless of configuration options and
     # runtime factors they are processed after pivot_root (on classic systems)
     # so snap.rootfs is not a factor.
-    mount options=(rw bind) /** -> /**,
-    mount options=(ro bind) /** -> /**,
+    mount options=(rw bind),
+    mount options=(ro bind),
 
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir

--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -1,7 +1,7 @@
 # Author: Jamie Strandboge <jamie@canonical.com>
 #include <tunables/global>
 
-/usr/bin/snap-confine (attach_disconnected) {
+/usr/lib/snapd/snap-confine (attach_disconnected) {
     # We run privileged, so be fanatical about what we include and don't use
     # any abstractions
     /etc/ld.so.cache r,
@@ -103,6 +103,8 @@
     mount options=(rw rbind) /var/lib/snapd/ -> /tmp/snap.rootfs_*/var/lib/snapd/,
     mount options=(rw rbind) /var/snap/ -> /tmp/snap.rootfs_*/var/snap/,
     mount options=(rw rbind) /var/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
+    mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
+    mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
     # This is used when --enable-rootfs-is-core-snap is NOT used
     mount options=(rw bind) /snap/ubuntu-core/*/bin/ -> /bin/,
@@ -112,6 +114,15 @@
     mount options=(rw bind) /snap/ubuntu-core/*/libx32/ -> /libx32/,
     mount options=(rw bind) /snap/ubuntu-core/*/lib64/ -> /lib64/,
     mount options=(rw bind) /snap/ubuntu-core/*/usr/ -> /usr/,
+    mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /etc/alternatives/,
+
+    # This is a somewhat of a blank check for mount profiles.  Mount profiles
+    # are written by the trusted snapd to a root-writable location and
+    # processed by snap-confine. Regardless of configuration options and
+    # runtime factors they are processed after pivot_root (on classic systems)
+    # so snap.rootfs is not a factor.
+    mount options=(rw bind) /** -> /**,
+    mount options=(ro bind) /** -> /**,
 
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir

--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -117,8 +117,8 @@
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /etc/alternatives/,
 
     # Allow snaps to share content amongst themselves.
-    mount options=(rw bind) /snap/*/** -> /snap/*/**,
-    mount options=(ro bind) /snap/*/** -> /snap/*/**,
+    mount options=(rw bind) /snap/*/*/** -> /snap/*/*/**,
+    mount options=(ro bind) /snap/*/*/** -> /snap/*/*/**,
     # But we don't want anyone to touch /snap/bin
     audit deny mount /snap/bin/** -> /**,
     audit deny mount /** -> /snap/bin/**,

--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -116,7 +116,7 @@
     mount options=(rw bind) /snap/ubuntu-core/*/usr/ -> /usr/,
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /etc/alternatives/,
 
-    # Allow snaps to share content amongst themselves.
+    # Support mount profiles via the content interface
     mount options=(rw bind) /snap/*/*/** -> /snap/*/*/**,
     mount options=(ro bind) /snap/*/*/** -> /snap/*/*/**,
     # But we don't want anyone to touch /snap/bin

--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -119,6 +119,9 @@
     # Allow snaps to share content amongst themselves.
     mount options=(rw bind) /snap/*/** -> /snap/*/**,
     mount options=(ro bind) /snap/*/** -> /snap/*/**,
+    # But we don't want anyone to touch /snap/bin
+    deny audit mount /snap/bin/** -> /**,
+    deny audit mount /** -> /snap/bin/**,
 
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir

--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -120,8 +120,8 @@
     mount options=(rw bind) /snap/*/** -> /snap/*/**,
     mount options=(ro bind) /snap/*/** -> /snap/*/**,
     # But we don't want anyone to touch /snap/bin
-    deny audit mount /snap/bin/** -> /**,
-    deny audit mount /** -> /snap/bin/**,
+    audit deny mount /snap/bin/** -> /**,
+    audit deny mount /** -> /snap/bin/**,
 
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir

--- a/spread-tests/mount-profiles-bin-snap-destination/task.yaml
+++ b/spread-tests/mount-profiles-bin-snap-destination/task.yaml
@@ -1,13 +1,13 @@
-summary: Apparmor profile prevents bind-mounting from /snap/bin
+summary: Apparmor profile prevents bind-mounting to /snap/bin
 # This is blacklisted on debian because it relies on apparmor mount mediation
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
     snap install snapd-hacker-toolbelt
     echo "We can change its mount profile externally to create bind mount /snap/bin somewhere"
-    echo "/snap/bin -> /snap/snapd-hacker-toolbelt/mnt"
+    echo "/snap/snapd-hacker-toolbelt/mnt -> /snap/bin"
     mkdir -p /var/lib/snapd/mount
-    echo "/snap/bin /snap/snapd-hacker-toolbelt/current/mnt none bind,ro 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
+    echo "/snap/snapd-hacker-toolbelt/current/mnt /snap/bin none bind,ro 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
 execute: |
     cd /
     echo "Let's clear the kernel ring buffer"
@@ -18,7 +18,7 @@ execute: |
     ! /snap/bin/snapd-hacker-toolbelt.busybox true
     sysctl -w kernel.printk_ratelimit=$orig_ratelimit
     echo "Not only the command failed because snap-confine failed, we see why!"
-    dmesg | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/snapd-hacker-toolbelt/[0-9]\+/mnt/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/bin/" flags="rw, bind"'
+    dmesg | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/bin/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/snapd-hacker-toolbelt/[0-9]\+/mnt/" flags="rw, bind"'
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt

--- a/spread-tests/mount-profiles-bin-snap-source/task.yaml
+++ b/spread-tests/mount-profiles-bin-snap-source/task.yaml
@@ -1,0 +1,23 @@
+summary: Check that apparmor profiles prevents bind mounting /snap/bin anywhere
+# This is blacklisted on debian because it relies on apparmor mount mediation
+systems: [-debian-8]
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+    echo "We can change its mount profile externally to create bind mount /snap/bin somewhere"
+    echo "/snap/bin -> /snap/snapd-hacker-toolbelt/mnt"
+    mkdir -p /var/lib/snapd/mount
+    echo "/snap/bin /snap/snapd-hacker-toolbelt/current/mnt none bind,ro 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
+    sysctl -w kernel.printk_ratelimit=0
+execute: |
+    cd /
+    echo "Let's clear the kernel ring buffer"
+    dmesg -c
+    echo "We can now run busybox true and expect it to fail"
+    ! /snap/bin/snapd-hacker-toolbelt.busybox true
+    echo "Not only the command failed because snap-confine failed, we see why!"
+    dmesg | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/snapd-hacker-toolbelt/[0-9]\+/mnt/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/bin/" flags="rw, bind"'
+restore: |
+    snap remove snapd-hacker-toolbelt
+    rm -rf /var/snap/snapd-hacker-toolbelt
+    rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab

--- a/spread-tests/mount-profiles-ro-mount/task.yaml
+++ b/spread-tests/mount-profiles-ro-mount/task.yaml
@@ -1,26 +1,18 @@
 summary: Check that read-only bind mounts can be created
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+    echo "We can change its mount profile externally to create a read-only bind-mount"
+    echo "/snap/snapd-hacker-toolbelt/current/src -> /snap/snapd-hacker-toolbelt/current/dst"
+    mkdir -p /var/lib/snapd/mount
+    echo "/snap/snapd-hacker-toolbelt/current/src /snap/snapd-hacker-toolbelt/current/dst none bind,ro 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
+execute: |
+    cd /
+    echo "We can now look at the .id file in the destination directory"
+    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox cat /snap/snapd-hacker-toolbelt/current/dst/.id)" = "source" ]
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-execute: |
-    echo "Having installed the snapd-hacker-toolbelt snap"
-    snap list | grep -q snapd-hacker-toolbelt || snap install snapd-hacker-toolbelt
-
-    echo "We can change its mount profile externally to create a read-only bind-mount"
-    echo "/var/snap/snapd-hacker-toolbelt/common/src -> /var/snap/snapd-hacker-toolbelt/common/dst"
-    mkdir -p /var/lib/snapd/mount
-    echo "/var/snap/snapd-hacker-toolbelt/common/src /var/snap/snapd-hacker-toolbelt/common/dst none bind,ro 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-    
-    echo "We can now create both test directories"
-    mkdir -p /var/snap/snapd-hacker-toolbelt/common/src
-    mkdir -p /var/snap/snapd-hacker-toolbelt/common/dst
-    
-    echo "And put a canary file with a random value inside"
-    value="canary-$(dd if=/dev/urandom bs=4 count=1 2>/dev/null | od -A none -t x4 | cut -f 2 -d ' ')"
-    echo "$value" > /var/snap/snapd-hacker-toolbelt/common/src/canary
-
-    echo "We can now run busybox.cat from the destination directory and expect the random value to match"
-    [ "$(cd / && /snap/bin/snapd-hacker-toolbelt.busybox cat /var/snap/snapd-hacker-toolbelt/common/dst/canary)" = "$value" ]

--- a/spread-tests/mount-profiles-rw-mount/task.yaml
+++ b/spread-tests/mount-profiles-rw-mount/task.yaml
@@ -1,4 +1,4 @@
-summary: Check that read-only bind mounts can be created
+summary: Check that read-write bind mounts can be created
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
 prepare: |

--- a/spread-tests/mount-profiles-rw-mount/task.yaml
+++ b/spread-tests/mount-profiles-rw-mount/task.yaml
@@ -1,28 +1,24 @@
-summary: Check that write-only bind mounts can be created
+summary: Check that read-only bind mounts can be created
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+    echo "We can connect it to the mount-observe slot from the core"
+    snap connect snapd-hacker-toolbelt:mount-observe ubuntu-core:mount-observe
+    echo "We can change its mount profile externally to create a read-only bind-mount"
+    echo "/snap/snapd-hacker-toolbelt/current/src -> /snap/snapd-hacker-toolbelt/current/dst"
+    mkdir -p /var/lib/snapd/mount
+    echo "/snap/snapd-hacker-toolbelt/current/src /snap/snapd-hacker-toolbelt/current/dst none bind,rw 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
+execute: |
+    cd /
+    echo "We can now look at the .id file in the destination directory"
+    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox cat /snap/snapd-hacker-toolbelt/current/dst/.id)" = "source" ]
+    echo "As well as the current mount points"
+    # FIXME: this doesn't show 'rw', bind mounts confuse most tools and it
+    # seems that busybox is not any different here.
+    /snap/bin/snapd-hacker-toolbelt.busybox mount | grep snapd-hacker-toolbelt
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-execute: |
-    echo "Having installed the snapd-hacker-toolbelt snap"
-    snap list | grep -q snapd-hacker-toolbelt || snap install snapd-hacker-toolbelt
-
-    echo "We can change its mount profile externally to create a writable bind-mount"
-    echo "/var/snap/snapd-hacker-toolbelt/common/src -> /var/snap/snapd-hacker-toolbelt/common/dst"
-    mkdir -p /var/lib/snapd/mount
-    echo "/var/snap/snapd-hacker-toolbelt/common/src /var/snap/snapd-hacker-toolbelt/common/dst none bind,rw 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-    
-    echo "We can now create both test directories"
-    mkdir -p /var/snap/snapd-hacker-toolbelt/common/src
-    mkdir -p /var/snap/snapd-hacker-toolbelt/common/dst
-    chmod 0777 /var/snap/snapd-hacker-toolbelt/common/dst
-    
-    value="canary-$(dd if=/dev/urandom bs=4 count=1 2>/dev/null | od -A none -t x4 | cut -f 2 -d ' ')"
-
-    echo "We can now run busybox.tee to write to the file in the destination directory"
-    ( cd / && echo "$value" | /snap/bin/snapd-hacker-toolbelt.busybox tee /var/snap/snapd-hacker-toolbelt/common/dst/canary )
-
-    echo "And we should see the written value from the source directory"
-    [ "$(cat /var/snap/snapd-hacker-toolbelt/common/src/canary)" = "$value" ]

--- a/spread-tests/regression/lp-1599891/task.yaml
+++ b/spread-tests/regression/lp-1599891/task.yaml
@@ -1,0 +1,9 @@
+summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1599891
+# This is blacklisted on debian because debian doesn't use apparmor yet
+systems: [-debian-8]
+execute: |
+    snap_confine=$(realpath $(which ubuntu-core-launcher))
+    echo "Seeing that snap-confine is in $snap_confine"
+
+    echo "I also see a corresponding apparmor profile"
+    grep -F -q "$snap_confine (enforce)"  "/sys/kernel/security/apparmor/profiles"


### PR DESCRIPTION
During the recent move of snap-confine of $libexecdir from /usr/lib to
/usr/lib/snapd the apparmor profile effectively did nothing. This patch
corrects the path and adds rules required for additonal functionality added
since the rename.

Thanks to Jamie Strandboge for identifying the problem.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
