### PR TITLE
Debian spread tests

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,16 +10,16 @@ include /usr/share/dpkg/buildflags.mk
 # security of the system.  Discuss a proper approach to this for downstreams
 # if and when they approach us
 ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
-    VENDOR_ARGS=--enable-rootfs-is-core-snap
+    VENDOR_ARGS=--enable-nvidia-ubuntu
 else
-    VENDOR_ARGS=--disable-confinement
+    VENDOR_ARGS=--disable-apparmor
 endif
 
 %:
 	dh $@ --with autoreconf
 
 override_dh_auto_configure:
-	./configure --enable-nvidia-ubuntu --prefix=/usr --libexecdir=/usr/lib/snapd $(VENDOR_ARGS)
+	./configure --enable-rootfs-is-core-snap --prefix=/usr --libexecdir=/usr/lib/snapd $(VENDOR_ARGS)
 
 override_dh_fixperms:
 	dh_fixperms -Xusr/lib/snapd/snap-confine

--- a/spread-tests/cgroup-used/task.yaml
+++ b/spread-tests/cgroup-used/task.yaml
@@ -1,6 +1,4 @@
 summary: Check that launcher cgroup functionality works
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 restore: |
     snap remove hello-world
     rm -f /etc/udev/rules.d/70-spread-test.rules

--- a/spread-tests/hello-world-is-confined/task.yaml
+++ b/spread-tests/hello-world-is-confined/task.yaml
@@ -1,0 +1,13 @@
+summary: Check that hello-world.evil is confined
+# This is blacklisted on distributions without full confinement
+systems: [-debian-8, -debian-sid-grub]
+restore: |
+    snap remove hello-world
+execute: |
+    cd /
+    echo Run some hello-world stuff
+    snap install hello-world
+    hello-world.echo | grep Hello
+    hello-world.env | grep SNAP_NAME=hello-world
+    echo Ensure that we get an error if hello-world.evil does not return an error
+    if hello-world.evil; then exit 1; fi

--- a/spread-tests/hello-world-is-confined/task.yaml
+++ b/spread-tests/hello-world-is-confined/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that hello-world.evil is confined
 # This is blacklisted on distributions without full confinement
-systems: [-debian-8, -debian-sid-grub]
+systems: [-debian-sid-grub]
 restore: |
     snap remove hello-world
 execute: |

--- a/spread-tests/hello-world-runs/task.yaml
+++ b/spread-tests/hello-world-runs/task.yaml
@@ -1,6 +1,4 @@
 summary: Check that hello-world can be installed and works correctly
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 restore: |
     snap remove hello-world
 execute: |

--- a/spread-tests/hello-world-runs/task.yaml
+++ b/spread-tests/hello-world-runs/task.yaml
@@ -1,4 +1,4 @@
-summary: Check that basic install works
+summary: Check that hello-world can be installed and works correctly
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
 restore: |
@@ -9,5 +9,3 @@ execute: |
     snap install hello-world
     hello-world.echo | grep Hello
     hello-world.env | grep SNAP_NAME=hello-world
-    echo Ensure that we get an error if hello-world.evil does not return an error
-    if hello-world.evil; then exit 1; fi

--- a/spread-tests/mount-profiles-missing-dst/task.yaml
+++ b/spread-tests/mount-profiles-missing-dst/task.yaml
@@ -1,6 +1,4 @@
 summary: Check that missing destination directory aborts mount processing
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
@@ -13,9 +11,9 @@ execute: |
     echo "/var/snap/snapd-hacker-toolbelt/common/src -> /var/snap/snapd-hacker-toolbelt/common/dst"
     mkdir -p /var/lib/snapd/mount
     echo "/var/snap/snapd-hacker-toolbelt/common/src /var/snap/snapd-hacker-toolbelt/common/dst none bind,ro 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-    
+
     echo "We can now create the source directory, missing the destination directory"
     mkdir -p /var/snap/snapd-hacker-toolbelt/common/src
-    
+
     echo "We can now run busybox.true and expect it to fail"
-    ( cd / && ! /snap/bin/snapd-hacker-toolbelt.busybox true ) 
+    ( cd / && ! /snap/bin/snapd-hacker-toolbelt.busybox true )

--- a/spread-tests/mount-profiles-missing-src/task.yaml
+++ b/spread-tests/mount-profiles-missing-src/task.yaml
@@ -1,6 +1,4 @@
 summary: Check that missing source directory aborts mount processing
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
@@ -13,9 +11,9 @@ execute: |
     echo "/var/snap/snapd-hacker-toolbelt/common/src -> /var/snap/snapd-hacker-toolbelt/common/dst"
     mkdir -p /var/lib/snapd/mount
     echo "/var/snap/snapd-hacker-toolbelt/common/src /var/snap/snapd-hacker-toolbelt/common/dst none bind,ro 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-    
+
     echo "We can now create the destination directory, missing the source directory"
     mkdir -p /var/snap/snapd-hacker-toolbelt/common/dst
-    
+
     echo "We can now run busybox.true and expect it to fail"
-    ( cd / && ! /snap/bin/snapd-hacker-toolbelt.busybox true ) 
+    ( cd / && ! /snap/bin/snapd-hacker-toolbelt.busybox true )

--- a/spread-tests/mount-profiles-mount-tmpfs/task.yaml
+++ b/spread-tests/mount-profiles-mount-tmpfs/task.yaml
@@ -1,6 +1,4 @@
 summary: Check that mount profiles cannot be used to mount tmpfs
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
@@ -12,9 +10,9 @@ execute: |
     echo "We can change its mount profile externally to mount tmpfs at /var/snap/snapd-hacker-toolbelt/mnt"
     mkdir -p /var/lib/snapd/mount
     echo "none /var/snap/snapd-hacker-toolbelt/common/mnt tmpfs rw 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-    
+
     echo "We can now create the test mount directory"
     mkdir -p /var/snap/snapd-hacker-toolbelt/common/mnt
-    
+
     echo "We can now run busybox.true and expect it to fail"
     ( cd / && ! /snap/bin/snapd-hacker-toolbelt.busybox true )

--- a/spread-tests/mount-profiles-ro-mount/task.yaml
+++ b/spread-tests/mount-profiles-ro-mount/task.yaml
@@ -1,6 +1,4 @@
 summary: Check that read-only bind mounts can be created
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
@@ -13,11 +11,11 @@ execute: |
     echo "/var/snap/snapd-hacker-toolbelt/common/src -> /var/snap/snapd-hacker-toolbelt/common/dst"
     mkdir -p /var/lib/snapd/mount
     echo "/var/snap/snapd-hacker-toolbelt/common/src /var/snap/snapd-hacker-toolbelt/common/dst none bind,ro 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-    
+
     echo "We can now create both test directories"
     mkdir -p /var/snap/snapd-hacker-toolbelt/common/src
     mkdir -p /var/snap/snapd-hacker-toolbelt/common/dst
-    
+
     echo "And put a canary file with a random value inside"
     value="canary-$(dd if=/dev/urandom bs=4 count=1 2>/dev/null | od -A none -t x4 | cut -f 2 -d ' ')"
     echo "$value" > /var/snap/snapd-hacker-toolbelt/common/src/canary

--- a/spread-tests/mount-profiles-rw-mount/task.yaml
+++ b/spread-tests/mount-profiles-rw-mount/task.yaml
@@ -1,6 +1,4 @@
 summary: Check that write-only bind mounts can be created
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
@@ -13,12 +11,12 @@ execute: |
     echo "/var/snap/snapd-hacker-toolbelt/common/src -> /var/snap/snapd-hacker-toolbelt/common/dst"
     mkdir -p /var/lib/snapd/mount
     echo "/var/snap/snapd-hacker-toolbelt/common/src /var/snap/snapd-hacker-toolbelt/common/dst none bind,rw 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-    
+
     echo "We can now create both test directories"
     mkdir -p /var/snap/snapd-hacker-toolbelt/common/src
     mkdir -p /var/snap/snapd-hacker-toolbelt/common/dst
     chmod 0777 /var/snap/snapd-hacker-toolbelt/common/dst
-    
+
     value="canary-$(dd if=/dev/urandom bs=4 count=1 2>/dev/null | od -A none -t x4 | cut -f 2 -d ' ')"
 
     echo "We can now run busybox.tee to write to the file in the destination directory"

--- a/spread-tests/regression/lp-1580018/task.yaml
+++ b/spread-tests/regression/lp-1580018/task.yaml
@@ -1,12 +1,10 @@
 summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1580018
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 execute: |
     cd /
     echo "Having installed the snapd-hacker-toolbelt snap"
     snap list | grep -q snapd-hacker-toolbelt || snap install snapd-hacker-toolbelt
 
-    echo "We can check the inode number of /etc/alternatives" 
+    echo "We can check the inode number of /etc/alternatives"
     host_inode="$(stat -c '%i' /etc/alternatives)"
     core_inode="$(stat -c '%i' /snap/ubuntu-core/current/etc/alternatives)"
     effective_inode="$(/snap/bin/snapd-hacker-toolbelt.busybox stat -c '%i' /etc/alternatives)"

--- a/spread-tests/regression/lp-1595444/task.yaml
+++ b/spread-tests/regression/lp-1595444/task.yaml
@@ -1,6 +1,4 @@
 summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1595444
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
@@ -9,7 +7,7 @@ execute: |
     snap list | grep -q snapd-hacker-toolbelt || snap install snapd-hacker-toolbelt
 
     echo "We can go to a location that is available in all snaps (/tmp)"
-    echo "We can run the 'cwd' tool from busybox and it reports /tmp" 
+    echo "We can run the 'cwd' tool from busybox and it reports /tmp"
     [ "$(cd /tmp && /snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "/tmp" ]
 
     echo "But if we go to a location that is not available to snaps (e.g. $HOME/.cache)"

--- a/spread-tests/ubuntu-core-launcher-exists/task.yaml
+++ b/spread-tests/ubuntu-core-launcher-exists/task.yaml
@@ -1,6 +1,4 @@
 summary: Check that ubuntu-core-launcher executes correctly
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 execute: |
     echo "ubuntu-core-launcher is installed and responds to --help"
     ubuntu-core-launcher --help 2>&1 | grep -F -q 'Usage: ubuntu-core-launcher <security-tag> <binary>'

--- a/spread-tests/unit-tests/task.yaml
+++ b/spread-tests/unit-tests/task.yaml
@@ -1,6 +1,4 @@
 summary: Run internal unit tests
-# This is blacklisted on debian because we first have to get the dpkg-vendor patches
-systems: [-debian-8]
 execute: |
     cd /remote/path/
     autoreconf --install --force

--- a/spread.yaml
+++ b/spread.yaml
@@ -10,7 +10,7 @@ backends:
         systems:
             - ubuntu-16.04-64-grub
             # - ubuntu-16.04-32-grub
-            - debian-8
+            - debian-sid-grub
 
 path: /remote/path/
 
@@ -28,7 +28,6 @@ prepare: |
             trap "sysctl -w net.ipv6.conf.all.disable_ipv6=0" EXIT
             ;;
         debian)
-            echo "deb http://ftp.de.debian.org/debian sid main" > /etc/apt/sources.list.d/snappy.list
             ;;
     esac
     case $release_ID in


### PR DESCRIPTION
This patch just removes various blacklists that kept tests from running
on Jessie. Now that we have a Sid image we can run tests there.
