### PR TITLE
add a regression test for LP: #1599608

### DIFF
--- a/spread-tests/regression/lp-1599608/task.yaml
+++ b/spread-tests/regression/lp-1599608/task.yaml
@@ -37,9 +37,9 @@ execute: |
     PATH=/foo:$PATH TESTVAR=bar hello-world.env | grep PATH
     cat /run/udev/spread-test.out
     echo "Ensure user-specified PATH is not used"
-    !grep 'PATH=/foo' /run/udev/spread-test.out
+    ! grep 'PATH=/foo' /run/udev/spread-test.out
     echo "Ensure environment is clean"
-    !grep 'TESTVAR=bar' /run/udev/spread-test.out
+    ! grep 'TESTVAR=bar' /run/udev/spread-test.out
 restore: |
     echo "Remove hello-world"
     snap remove hello-world

--- a/spread-tests/regression/lp-1599608/task.yaml
+++ b/spread-tests/regression/lp-1599608/task.yaml
@@ -9,6 +9,36 @@
 summary: Check that execle doesn't regress
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
+prepare: |
+    cd /
+    echo "Install hello-world"
+    snap install hello-world
+    # all of this ls madness can go away when we have remote environment
+    # variables
+    echo "Unmount original core snap"
+    umount $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
+    mv $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1).orig
+    echo "Create modified core snap for snappy-app-dev"
+    unsquashfs $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1)
+    echo 'echo PATH=$PATH > /run/udev/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
+    echo 'echo TESTVAR=$TESTVAR >> /run/udev/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
+    mksquashfs ./squashfs-root $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1 | sed 's/.orig//') -comp xz
+    if [ ! -e $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) ]; then exit 1; fi
+    echo "Mount modified core snap"
+    mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
+execute: |
+    echo "Add a udev tag so affected code branch is exercised"
+    echo 'KERNEL=="uinput", TAG+="snap_hello-world_env"' > /etc/udev/rules.d/70-spread-test.rules
+    udevadm control --reload-rules
+    udevadm settle
+    udevadm trigger
+    udevadm settle
+    PATH=/foo:$PATH TESTVAR=bar hello-world.env | grep PATH
+    cat /run/udev/spread-test.out
+    echo "Ensure user-specified PATH is not used"
+    !grep 'PATH=/foo' /run/udev/spread-test.out
+    echo "Ensure environment is clean"
+    !grep 'TESTVAR=bar' /run/udev/spread-test.out
 restore: |
     echo "Remove hello-world"
     snap remove hello-world
@@ -20,38 +50,9 @@ restore: |
     echo "Mount the original core snap"
     mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
     rm -rf /squashfs-root
-    rm -f /run/spread-test.out
+    rm -f /run/udev/spread-test.out
     rm -f /etc/udev/rules.d/70-spread-test.rules
     udevadm control --reload-rules
     udevadm settle
     udevadm trigger
     udevadm settle
-execute: |
-    cd /
-    echo "Install hello-world"
-    snap install hello-world
-    # all of this ls madness can go away when we have remote environment
-    # variables
-    echo "Unmount original core snap"
-    umount $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
-    mv $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1).orig
-    echo "Create modified core snap for snappy-app-dev"
-    unsquashfs $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1)
-    echo 'echo PATH=$PATH > /run/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
-    echo 'echo TESTVAR=$TESTVAR >> /run/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
-    mksquashfs ./squashfs-root $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1 | sed 's/.orig//') -comp xz
-    if [ ! -e $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) ]; then exit 1; fi
-    echo "Mount modified core snap"
-    mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
-    echo "Add a udev tag so affected code branch is exercised"
-    echo 'KERNEL=="uinput", TAG+="snap_hello-world_env"' > /etc/udev/rules.d/70-spread-test.rules
-    udevadm control --reload-rules
-    udevadm settle
-    udevadm trigger
-    udevadm settle
-    PATH=/foo:$PATH TESTVAR=bar hello-world.env | grep PATH
-    cat /run/spread-test.out
-    echo "Ensure user-specified PATH is not used"
-    !grep 'PATH=/foo' /run/spread-test.out
-    echo "Ensure environment is clean"
-    !grep 'TESTVAR=bar' /run/spread-test.out

--- a/spread-tests/regression/lp-1599608/task.yaml
+++ b/spread-tests/regression/lp-1599608/task.yaml
@@ -34,7 +34,6 @@ execute: |
     # variables
     echo Unmount original OS snap
     umount $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
-    mount | grep core || true
     mv $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1).orig
     echo Create modified OS snap for snappy-app-dev
     unsquashfs $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1)

--- a/spread-tests/regression/lp-1599608/task.yaml
+++ b/spread-tests/regression/lp-1599608/task.yaml
@@ -27,6 +27,7 @@ prepare: |
     echo "Mount modified core snap"
     mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
 execute: |
+    cd /
     echo "Add a udev tag so affected code branch is exercised"
     echo 'KERNEL=="uinput", TAG+="snap_hello-world_env"' > /etc/udev/rules.d/70-spread-test.rules
     udevadm control --reload-rules

--- a/spread-tests/regression/lp-1599608/task.yaml
+++ b/spread-tests/regression/lp-1599608/task.yaml
@@ -1,23 +1,23 @@
 # The setup for this test is unorthodox because by the time the cgroup code
 # is executed, the mounts are in place and /lib/udev/snappy-app-dev from the
-# OS snap is used. Unfortunately, simple bind mounts over
-# /snap/ubuntu-core/current/lib/udev don't work and the OS snap must be
+# core snap is used. Unfortunately, simple bind mounts over
+# /snap/ubuntu-core/current/lib/udev don't work and the core snap must be
 # unpacked, lib/udev/snappy-app-dev modified to be tested, repacked and
-# mounted. We unmount the OS snap and move it aside to avoid both the original
-# and the updated OS snap from being mounted on the same mount point, which
-# confuses the kernel.
+# mounted. We unmount the core snap and move it aside to avoid both the
+# original and the updated core snap from being mounted on the same mount
+# point, which confuses the kernel.
 summary: Check that execle doesn't regress
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
 restore: |
-    echo Remove hello-world
+    echo "Remove hello-world"
     snap remove hello-world
-    echo Unmount the modified OS snap
+    echo "Unmount the modified core snap"
     # all of this ls madness can go away when we have remote environment
     # variables
     umount $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
     if [ "x"$(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1) != "x" ]; then mv -f $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1) $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1 | sed 's/.orig//') ; fi
-    echo Mount the original OS snap
+    echo "Mount the original core snap"
     mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
     rm -rf /squashfs-root
     rm -f /run/spread-test.out
@@ -28,23 +28,22 @@ restore: |
     udevadm settle
 execute: |
     cd /
-    echo Install hello-world
+    echo "Install hello-world"
     snap install hello-world
     # all of this ls madness can go away when we have remote environment
     # variables
-    echo Unmount original OS snap
+    echo "Unmount original core snap"
     umount $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
     mv $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1).orig
-    echo Create modified OS snap for snappy-app-dev
+    echo "Create modified core snap for snappy-app-dev"
     unsquashfs $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1)
     echo 'echo PATH=$PATH > /run/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
     echo 'echo TESTVAR=$TESTVAR >> /run/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
     mksquashfs ./squashfs-root $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1 | sed 's/.orig//') -comp xz
     if [ ! -e $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) ]; then exit 1; fi
-    echo Mount modified OS snap
+    echo "Mount modified core snap"
     mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
-    mount | grep core || true
-    echo Add a udev tag so affected code branch is exercised
+    echo "Add a udev tag so affected code branch is exercised"
     echo 'KERNEL=="uinput", TAG+="snap_hello-world_env"' > /etc/udev/rules.d/70-spread-test.rules
     udevadm control --reload-rules
     udevadm settle
@@ -52,5 +51,7 @@ execute: |
     udevadm settle
     PATH=/foo:$PATH TESTVAR=bar hello-world.env | grep PATH
     cat /run/spread-test.out
+    echo "Ensure user-specified PATH is not used"
     if grep 'PATH=/foo' /run/spread-test.out ; then exit 1; fi
+    echo "Ensure environment is clean"
     if grep 'TESTVAR=bar' /run/spread-test.out ; then exit 1; fi

--- a/spread-tests/regression/lp-1599608/task.yaml
+++ b/spread-tests/regression/lp-1599608/task.yaml
@@ -52,6 +52,6 @@ execute: |
     PATH=/foo:$PATH TESTVAR=bar hello-world.env | grep PATH
     cat /run/spread-test.out
     echo "Ensure user-specified PATH is not used"
-    if grep 'PATH=/foo' /run/spread-test.out ; then exit 1; fi
+    !grep 'PATH=/foo' /run/spread-test.out
     echo "Ensure environment is clean"
-    if grep 'TESTVAR=bar' /run/spread-test.out ; then exit 1; fi
+    !grep 'TESTVAR=bar' /run/spread-test.out

--- a/spread-tests/regression/lp-1599608/task.yaml
+++ b/spread-tests/regression/lp-1599608/task.yaml
@@ -1,0 +1,57 @@
+# The setup for this test is unorthodox because by the time the cgroup code
+# is executed, the mounts are in place and /lib/udev/snappy-app-dev from the
+# OS snap is used. Unfortunately, simple bind mounts over
+# /snap/ubuntu-core/current/lib/udev don't work and the OS snap must be
+# unpacked, lib/udev/snappy-app-dev modified to be tested, repacked and
+# mounted. We unmount the OS snap and move it aside to avoid both the original
+# and the updated OS snap from being mounted on the same mount point, which
+# confuses the kernel.
+summary: Check that execle doesn't regress
+# This is blacklisted on debian because we first have to get the dpkg-vendor patches
+systems: [-debian-8]
+restore: |
+    echo Remove hello-world
+    snap remove hello-world
+    echo Unmount the modified OS snap
+    # all of this ls madness can go away when we have remote environment
+    # variables
+    umount $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
+    if [ "x"$(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1) != "x" ]; then mv -f $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1) $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1 | sed 's/.orig//') ; fi
+    echo Mount the original OS snap
+    mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
+    rm -rf /squashfs-root
+    rm -f /run/spread-test.out
+    rm -f /etc/udev/rules.d/70-spread-test.rules
+    udevadm control --reload-rules
+    udevadm settle
+    udevadm trigger
+    udevadm settle
+execute: |
+    cd /
+    echo Install hello-world
+    snap install hello-world
+    # all of this ls madness can go away when we have remote environment
+    # variables
+    echo Unmount original OS snap
+    umount $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
+    mount | grep core || true
+    mv $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1).orig
+    echo Create modified OS snap for snappy-app-dev
+    unsquashfs $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1)
+    echo 'echo PATH=$PATH > /run/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
+    echo 'echo TESTVAR=$TESTVAR >> /run/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
+    mksquashfs ./squashfs-root $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1 | sed 's/.orig//') -comp xz
+    if [ ! -e $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) ]; then exit 1; fi
+    echo Mount modified OS snap
+    mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
+    mount | grep core || true
+    echo Add a udev tag so affected code branch is exercised
+    echo 'KERNEL=="uinput", TAG+="snap_hello-world_env"' > /etc/udev/rules.d/70-spread-test.rules
+    udevadm control --reload-rules
+    udevadm settle
+    udevadm trigger
+    udevadm settle
+    PATH=/foo:$PATH TESTVAR=bar hello-world.env | grep PATH
+    cat /run/spread-test.out
+    if grep 'PATH=/foo' /run/spread-test.out ; then exit 1; fi
+    if grep 'TESTVAR=bar' /run/spread-test.out ; then exit 1; fi


### PR DESCRIPTION
The setup for this test is unorthodox because by the time the cgroup code is executed, the mounts are in place and /lib/udev/snappy-app-dev from the OS snap is used. Unfortunately, simple bind mounts over /snap/ubuntu-core/current/lib/udev don't work and the OS snap must be unpacked, lib/udev/snappy-app-dev modified to be tested, repacked and mounted. We unmount the OS snap and move it aside to avoid both the original and the updated OS snap from being mounted on the same mount point, which confuses the kernel.
