### PR TITLE
Drop the alternative to ROOTFS_IS_CORE_SNAP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,25 +88,6 @@ PKG_CHECK_MODULES([UDEV], [udev])
 # Check for glib that we use for unit testing
 PKG_CHECK_MODULES([GLIB], [glib-2.0])
 
-# Allow to use the new execution environment based on pivot_root and bind-mount
-# of the core snap. This is closer to how an all-snap system would execute
-# applications (the root file system is a read only core snap) and is more
-# flexible in how the host OS can look like (it can have any directory layout)
-# and lastly it is much easier to implement arbitrary bind mounts from the
-# classic environment.
-AC_ARG_ENABLE([rootfs_is_core_snap],
-    AS_HELP_STRING([--enable-rootfs-is-core-snap], [Use core snap as the root file system]),
-    [case "${enableval}" in
-        yes) enable_rootfs_is_core_snap=yes ;;
-        no)  enable_rootfs_is_core_snap=no ;;
-        *) AC_MSG_ERROR([bad value ${enableval} for --enable-rootfs-is-core-snap])
-    esac], [enable_rootfs_is_core_snap=no])
-AM_CONDITIONAL([ROOTFS_IS_CORE_SNAP], [test "x$enable_rootfs_is_core_snap" = "xyes"])
-
-AS_IF([test "x$enable_rootfs_is_core_snap" = "xyes"], [
-    AC_DEFINE([ROOTFS_IS_CORE_SNAP], [1],
-        [Use the core snap as the root file system])])
-
 # Enable special support for hosts with proprietary nvidia drivers on Ubuntu.
 AC_ARG_ENABLE([nvidia-ubuntu],
     AS_HELP_STRING([--enable-nvidia-ubuntu], [Support for proprietary nvidia drivers (Ubuntu)]),

--- a/debian/rules
+++ b/debian/rules
@@ -10,16 +10,16 @@ include /usr/share/dpkg/buildflags.mk
 # security of the system.  Discuss a proper approach to this for downstreams
 # if and when they approach us
 ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
-    VENDOR_ARGS=--enable-rootfs-is-core-snap
+    VENDOR_ARGS=--enable-nvidia-ubuntu
 else
-    VENDOR_ARGS=--disable-confinement
+    VENDOR_ARGS=--disable-apparmor
 endif
 
 %:
 	dh $@ --with autoreconf
 
 override_dh_auto_configure:
-	./configure --enable-nvidia-ubuntu --prefix=/usr --libexecdir=/usr/lib/snapd $(VENDOR_ARGS)
+	./configure --prefix=/usr --libexecdir=/usr/lib/snapd $(VENDOR_ARGS)
 
 override_dh_fixperms:
 	dh_fixperms -Xusr/lib/snapd/snap-confine

--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -90,7 +90,8 @@
     /{tmp/snap.rootfs_*,}snap/ r,
     /{tmp/snap.rootfs_*,}snap/** r,
 
-    # This is used when --enable-rootfs-is-core-snap is used
+    # mount calls to setup the pivot_root based chroot with the core snap as
+    # the root filesystem.
     mount options=(rw bind) /snap/ubuntu-core/*/ -> /tmp/snap.rootfs_*/,
 
     mount options=(rw rbind) /dev/ -> /tmp/snap.rootfs_*/dev/,
@@ -105,16 +106,6 @@
     mount options=(rw rbind) /var/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
     mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
-
-    # This is used when --enable-rootfs-is-core-snap is NOT used
-    mount options=(rw bind) /snap/ubuntu-core/*/bin/ -> /bin/,
-    mount options=(rw bind) /snap/ubuntu-core/*/sbin/ -> /sbin/,
-    mount options=(rw bind) /snap/ubuntu-core/*/lib/ -> /lib/,
-    mount options=(rw bind) /snap/ubuntu-core/*/lib32/ -> /lib32/,
-    mount options=(rw bind) /snap/ubuntu-core/*/libx32/ -> /libx32/,
-    mount options=(rw bind) /snap/ubuntu-core/*/lib64/ -> /lib64/,
-    mount options=(rw bind) /snap/ubuntu-core/*/usr/ -> /usr/,
-    mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /etc/alternatives/,
 
     # Support mount profiles via the content interface
     mount options=(rw bind) /snap/*/*/** -> /snap/*/*/**,

--- a/spread-tests/unit-tests/task.yaml
+++ b/spread-tests/unit-tests/task.yaml
@@ -4,5 +4,5 @@ systems: [-debian-8]
 execute: |
     cd /remote/path/
     autoreconf --install --force
-    ./configure --enable-rootfs-is-core-snap
+    ./configure
     make -C src check-unit-tests


### PR DESCRIPTION
Since everyone is now shipping this code let’s simplify testing and
remove the old option entirely.
