### PR TITLE
Fix bind mounting of host filesystem and nvidia on Ubuntu

### DIFF
--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -106,6 +106,9 @@
     mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
+    # Allow to mount / as hostfs in the chroot
+    mount options=(ro bind) / -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
+
     # This is used when --enable-rootfs-is-core-snap is NOT used
     mount options=(rw bind) /snap/ubuntu-core/*/bin/ -> /bin/,
     mount options=(rw bind) /snap/ubuntu-core/*/sbin/ -> /sbin/,
@@ -126,7 +129,7 @@
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir
     /usr/** r,
-    mount options=(rw bind) /usr/lib/nvidia-*/ -> /var/lib/snapd/lib/gl/,
+    mount options=(rw bind) /usr/lib/nvidia-*/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/gl/,
 
     # for chroot on steroids, we use pivot_root as a better chroot that makes
     # apparmor rules behave the same on classic and outside of classic.

--- a/spread-tests/regression/lp-1602576/task.yaml
+++ b/spread-tests/regression/lp-1602576/task.yaml
@@ -1,0 +1,24 @@
+summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1602576
+# This is blacklisted on debian because debian doesn't use apparmor yet
+systems: [-debian-8]
+details: |
+    A missing apparmor profile entry for snap-confine has caused the
+    nvidia-on-ubuntu feature that bind mounts nvidia driver directory to fail.
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+    echo "We can fake the presence of the nvidia driver directory (/usr/lib/nvidia-361)"
+    mkdir -p /usr/lib/nvidia-361
+    echo "canary" > /usr/lib/nvidia-361/test.txt
+    echo "We also need to create /var/lib/snapd/hostfs that is not yet present in Ubuntu packaging"
+    # NOTE: This is addressed separately. Later on when this is not needed it
+    # should be removed from the test.
+    mkdir -p /var/lib/snapd/hostfs
+execute: |
+    echo "We can now check that the directory is mounted under /var/lib/snapd/lib/gl"
+    cd /
+    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox cat /var/lib/snapd/lib/gl/test.txt)" = "canary" ]
+restore: |
+    snap remove snapd-hacker-toolbelt
+    rm -rf /usr/lib/nvidia-361
+    rmdir /var/lib/snapd/hostfs

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -139,7 +139,7 @@ void setup_private_pts()
 	}
 }
 
-#ifdef NVIDIA_ARCH
+#ifdef ROOTFS_IS_CORE_SNAP
 static void sc_bind_mount_hostfs(const char *rootfs_dir)
 {
 	// Create a read-only bind mount from "/" to
@@ -156,7 +156,7 @@ static void sc_bind_mount_hostfs(const char *rootfs_dir)
 		}
 	}
 }
-#endif				// ifdef NVIDIA_ARCH
+#endif				// ifdef ROOTFS_IS_CORE_SNAP
 
 void setup_snappy_os_mounts()
 {
@@ -231,11 +231,7 @@ void setup_snappy_os_mounts()
 			die("cannot bind mount %s to %s", src, dst);
 		}
 	}
-#ifdef NVIDIA_ARCH
-	// Make this conditional on Nvidia support for Arch as Ubuntu doesn't use
-	// this so far and it requires a very recent version of the core snap.
 	sc_bind_mount_hostfs(rootfs_dir);
-#endif
 	sc_mount_nvidia_driver(rootfs_dir);
 	// Chroot into the new root filesystem so that / is the core snap.  Why are
 	// we using something as esoteric as pivot_root? Because this makes apparmor


### PR DESCRIPTION
This patch fixes the issue in which host filesystem and nvidia driver
couldn't be bind mounted. The host filesystem is now bind mounted
whenever we use --enable-rootfs-is-core-snap (i.e. always).

The issue was caused by two separate facts:
- the apparmor profile wasn't allowing the particular bind mount to
  happen
- the host filesystem wasn't mounted on ubuntu

This setup was tested earlier but due to apparmor issue where the
profile wasn't really applied it regressed and stopped working.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1602576
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
