### PR TITLE
Split seccomp handling into two phases

### DIFF
--- a/src/cleanup-funcs.c
+++ b/src/cleanup-funcs.c
@@ -15,8 +15,8 @@
  *
  */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include "cleanup-funcs.h"
+
 #include <mntent.h>
 
 void sc_cleanup_string(char **ptr)
@@ -35,3 +35,10 @@ void sc_cleanup_endmntent(FILE ** ptr)
 	if (*ptr != NULL)
 		endmntent(*ptr);
 }
+
+#ifdef HAVE_SECCOMP
+void sc_cleanup_seccomp_release(scmp_filter_ctx * ptr)
+{
+	seccomp_release(*ptr);
+}
+#endif				// HAVE_SECCOMP

--- a/src/cleanup-funcs.h
+++ b/src/cleanup-funcs.h
@@ -18,8 +18,15 @@
 #ifndef SNAP_CONFINE_CLEANUP_FUNCS_H
 #define SNAP_CONFINE_CLEANUP_FUNCS_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif				// HAVE_CONFIG_H
+
 #include <stdlib.h>
 #include <stdio.h>
+#ifdef HAVE_SECCOMP
+#include <seccomp.h>
+#endif				// HAVE_SECCOMP
 
 /**
  * Free a dynamically allocated string.
@@ -44,5 +51,15 @@ void sc_cleanup_file(FILE ** ptr);
  * __attribute__((cleanup(sc_cleanup_endmntent))).
  **/
 void sc_cleanup_endmntent(FILE ** ptr);
+
+#ifdef HAVE_SECCOMP
+/**
+ * Release a seccomp context with seccomp_release(3)
+ *
+ * This function is designed to be used with
+ * __attribute__((cleanup(sc_cleanup_seccomp_release))).
+ **/
+void sc_cleanup_seccomp_release(scmp_filter_ctx * ptr);
+#endif				// HAVE_SECCOMP
 
 #endif

--- a/src/seccomp-support.h
+++ b/src/seccomp-support.h
@@ -14,11 +14,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include <stdbool.h>
-
 #ifndef SNAP_CONFINE_SECCOMP_SUPPORT_H
 #define SNAP_CONFINE_SECCOMP_SUPPORT_H
 
-void seccomp_load_filters(const char *filter_profile);
+#include <seccomp.h>
+
+/**
+ * Prepare seccomp profile associated with the security tag.
+ *
+ * This function loads the seccomp profile from
+ * /var/lib/snapd/seccomp/profiles/$SECURITY_TAG and stores it into
+ * scmp_filter_ctx object.
+ *
+ * The object is returned to the caller and can be made effective with a call
+ * to sc_load_seccomp_context(). The returned value should be cleaned up with
+ * seccomp_release().
+ *
+ * This function calls die() on all errors.
+ **/
+
+scmp_filter_ctx sc_prepare_seccomp_context(const char *security_tag);
+
+/**
+ * Load a seccomp context.
+ *
+ * This function calls seccomp_load(3) and handles errors if it fails.
+ **/
+void sc_load_seccomp_context(scmp_filter_ctx ctx);
 
 #endif


### PR DESCRIPTION
This patch splits the current seccomp handling code into two phases. The
first phase runs before we start all the bind mount tricks and
pivot_root. This phase has unobstructed access to /var/lib/snapd/ from
the host filesystem.

The second phase just calls seccomp_load() on a context object made
during the first phase. It happens exactly at the same time we would
have parsed and loaded the context in the original code.

In effect this lets us stop bind mounting /var/lib/snapd from the host
into the application execution environment. This also lets us see
updated /var/lib/snapd mount points (like /var/lib/snapd/hostfs) with
new releases of the core snap, regardless of how the host distribution
packaging of snapd looks like.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
