### PR TITLE
Drop /var/lib/snapd bind mount

### DIFF
--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -189,7 +189,6 @@ void setup_snappy_os_mounts()
 		"/sys",		// fundamental filesystem
 		"/tmp",		// to get writable tmp
 		"/var/snap",	// to get access to global snap data
-		"/var/lib/snapd",	// to get access to snapd state and seccomp profiles
 		"/var/tmp",	// to get access to the other temporary directory
 		"/run",		// to get /run with sockets and what not
 		"/media",	// access to the users removable devices


### PR DESCRIPTION
This patch drops the /var/lib/snapd bind mount. In effect the
/var/lib/snapd directory will appear exactly as it is in the core snap.

In effect, at least since revision 138, the core snap now exposes the
hostfs directory under /var/lib/snapd/hostfs and this can be relied upon
by the nvidia driver mount code.

The downside is that /var/lib/snapd/ will be otherwise empty (no
state.json, etc) but since there is no interface for accessing that data
and we already have the snapd-control interface, this is deemed an
acceptable compromise.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
