### PR TITLE
Create /var/lib/snapd/hostfs if missing

### DIFF
--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -108,6 +108,8 @@
     mount options=(rw rbind) /media -> /tmp/snap.rootfs_*/media/,
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
+    # Allow to mkdir /var/lib/snapd/hostfs
+    mkdir /var/lib/snapd/hostfs/,
     # Allow to mount / as hostfs in the chroot
     mount options=(ro bind) / -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
 

--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -109,7 +109,7 @@
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
     # Allow to mkdir /var/lib/snapd/hostfs
-    mkdir /var/lib/snapd/hostfs/,
+    /var/lib/snapd/hostfs/ rw,
     # Allow to mount / as hostfs in the chroot
     mount options=(ro bind) / -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
 

--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -105,7 +105,7 @@
     mount options=(rw rbind) /var/snap/ -> /tmp/snap.rootfs_*/var/snap/,
     mount options=(rw rbind) /var/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
     mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
-    mount options=(rw rbind) /media -> /tmp/snap.rootfs_*/media/,
+    mount options=(rw rbind) /media/ -> /tmp/snap.rootfs_*/media/,
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
     # Allow to mkdir /var/lib/snapd/hostfs

--- a/spread-tests/hostfs-created-on-demand/task.yaml
+++ b/spread-tests/hostfs-created-on-demand/task.yaml
@@ -1,0 +1,24 @@
+summary: Check that /var/lib/snapd/hostfs is created on demand
+# This is blacklisted on debian because debian doesn't use apparmor yet
+systems: [-debian-8]
+details: |
+    The /var/lib/snapd/hostfs directory is created by snap-confine
+    if the host packaging of snapd doesn't already provide it.
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+    echo "We can move the packaged hostfs directory aside"
+    if [ -d /var/lib/snapd/hostfs ]; then
+        mv /var/lib/snapd/hostfs /var/lib/snapd/hostfs.orig
+    fi
+execute: |
+    cd /
+    echo "We can now run a busybox true just to ensure it started correctly"
+    /snap/bin/snapd-hacker-toolbelt.busybox true
+    echo "We can now check that the directory was created on the system"
+    test -d /var/lib/snapd/hostfs
+restore: |
+    snap remove snapd-hacker-toolbelt
+    if [ -d /var/lib/snapd/hostfs.orig ]; then
+        mv /var/lib/snapd/hostfs.orig /var/lib/snapd/hostfs
+    fi

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -137,6 +137,21 @@ void setup_private_pts()
 	}
 }
 
+/**
+ * The hostfs directory should be added by packaging of snapd but the release
+ * with this directory is not universally available so to unblock some other
+ * features we can simply create the directory directly.
+ **/
+static void sc_mkdir_hostfs_if_missing()
+{
+	if (access(SC_HOSTFS_DIR, F_OK) != 0) {
+		debug("creating missing hostfs directory");
+		if (mkdir(SC_HOSTFS_DIR, 0755) != 0) {
+			die("cannot create %s", SC_HOSTFS_DIR);
+		}
+	}
+}
+
 static void sc_bind_mount_hostfs(const char *rootfs_dir)
 {
 	// Create a read-only bind mount from "/" to
@@ -227,6 +242,7 @@ void setup_snappy_os_mounts()
 			die("cannot bind mount %s to %s", src, dst);
 		}
 	}
+	sc_mkdir_hostfs_if_missing();
 	sc_bind_mount_hostfs(rootfs_dir);
 	sc_mount_nvidia_driver(rootfs_dir);
 	// Chroot into the new root filesystem so that / is the core snap.  Why are


### PR DESCRIPTION
This patch simplifies coordination of downstream packaging by creating
the /var/lib/snapd/hostfs directory on demand inside snap-confine.

The hostfs directory is required for the nvidia driver bind mount
feature to work but it is not universally available yet due to delays in
downstream packaging changes and paperwork.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1603402
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
