### PR TITLE
Bind mount /lib/modules on classic

### DIFF
--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -106,6 +106,7 @@
     mount options=(rw rbind) /var/tmp/ -> /tmp/snap.rootfs_*/var/tmp/,
     mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
     mount options=(rw rbind) /media/ -> /tmp/snap.rootfs_*/media/,
+    mount options=(rw rbind) /lib/modules/ -> /tmp/snap.rootfs_*/lib/modules/,
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
     # Allow to mkdir /var/lib/snapd/hostfs

--- a/spread-tests/regression/lp-1597839/task.yaml
+++ b/spread-tests/regression/lp-1597839/task.yaml
@@ -1,0 +1,15 @@
+summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1597839
+# This is blacklisted on debian because debian doesn't use apparmor yet
+systems: [-debian-8]
+details: |
+    The snappy execution environment should contain the /lib/modules directory
+    from the host filesystem when running on a classic distribution
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+execute: |
+    cd /
+    echo "We can ensure that the /lib/modules/$(uname -r) directory exists"
+    /snap/bin/snapd-hacker-toolbelt.busybox test -d /lib/modules/$(uname -r)
+restore: |
+    snap remove snapd-hacker-toolbelt

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -205,6 +205,7 @@ void setup_snappy_os_mounts()
 		"/var/tmp",	// to get access to the other temporary directory
 		"/run",		// to get /run with sockets and what not
 		"/media",	// access to the users removable devices
+		"/lib/modules",	// access to the modules of the running kernel
 	};
 	for (int i = 0; i < sizeof(source_mounts) / sizeof *source_mounts; i++) {
 		const char *src = source_mounts[i];


### PR DESCRIPTION
This patch bind mounts the /lib/modules directory when running on a
classic system.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1597839
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
