### PR TITLE
Allow snap-confine to bind-mount fonts from the hostfs

### DIFF
--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -119,6 +119,8 @@
     # But we don't want anyone to touch /snap/bin
     audit deny mount /snap/bin/** -> /**,
     audit deny mount /** -> /snap/bin/**,
+    # Allow the content interface to bind fonts from the host filesystem
+    mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
 
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir


### PR DESCRIPTION
This patch allows snap-confine to do a read-only bind mount of the
/usr/share/fonts directory from the host filesystem. This is done in
anticipation of support of this feature in snapd.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
