### PR TITLE
Add --without-unit-tests option (#90)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,15 @@ AC_FUNC_FORK
 AC_FUNC_STRNLEN
 AC_CHECK_FUNCS([mkdir regcomp setenv strdup strerror])
 
+AC_ARG_WITH([unit-tests],
+    AC_HELP_STRING([--without-unit-tests], [do not build unit test programs]),
+    [case "${withval}" in
+        yes) with_unit_tests=yes ;;
+        no)  with_unit_tests=no ;;
+        *)   AC_MSG_ERROR([bad value ${withval} for --without-unit-tests])
+    esac], [with_unit_tests=yes])
+AM_CONDITIONAL([WITH_UNIT_TESTS], [test "x$with_unit_tests" = "xyes"])
+
 # Allow to build without apparmor support by calling:
 # ./configure --disable-apparmor
 # This makes it possible to run snaps in devmode on almost any host,
@@ -62,6 +71,11 @@ AM_CONDITIONAL([SECCOMP], [test "x$enable_seccomp" = "xyes"])
 # The tests are of smaller value as we port more and more tests to spread.
 AM_CONDITIONAL([CONFINEMENT_TESTS], [test "x$enable_apparmor" = "xyes" && test "x$enable_seccomp" = "xyes" && ((test "x$host_cpu" = "xx86_64" && test "x$build_cpu" = "xx86_64") || (test "x$host_cpu" = "xi686" && test "x$build_cpu" = "xi686"))])
 
+# Check for glib that we use for unit testing
+AS_IF([test "x$with_unit_tests" = "xyes"], [
+    PKG_CHECK_MODULES([GLIB], [glib-2.0])
+])
+
 # Check if seccomp userspace library is available
 AS_IF([test "x$enable_seccomp" = "xyes"], [
     PKG_CHECK_MODULES([SECCOMP], [libseccomp], [
@@ -85,8 +99,6 @@ AS_IF([test "x$enable_apparmor" = "xyes"], [
 # Those are now used unconditionally even if apparmor is disabled.
 PKG_CHECK_MODULES([LIBUDEV], [libudev])
 PKG_CHECK_MODULES([UDEV], [udev])
-# Check for glib that we use for unit testing
-PKG_CHECK_MODULES([GLIB], [glib-2.0])
 
 # Enable special support for hosts with proprietary nvidia drivers on Ubuntu.
 AC_ARG_ENABLE([nvidia-ubuntu],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,7 @@
 libexec_PROGRAMS = snap-confine
+if WITH_UNIT_TESTS
 noinst_PROGRAMS = snap-confine-unit-tests
+endif
 snap_confine_SOURCES = \
 	main.c \
 	sc-main.c \
@@ -43,6 +45,7 @@ snap_confine_CFLAGS += $(APPARMOR_CFLAGS)
 snap_confine_LDADD += $(APPARMOR_LIBS)
 endif
 
+if WITH_UNIT_TESTS
 snap_confine_unit_tests_SOURCES = \
 	unit-tests-main.c \
 	unit-tests.c \
@@ -54,6 +57,7 @@ snap_confine_unit_tests_SOURCES = \
 snap_confine_unit_tests_CFLAGS = $(snap_confine_CFLAGS) $(GLIB_CFLAGS)
 snap_confine_unit_tests_LDADD = $(snap_confine_LDADD) $(GLIB_LIBS)
 snap_confine_unit_tests_LDFLAGS = $(snap_confine_LDFLAGS)
+endif
 
 # Force particular coding style on all source and header files.
 .PHONY: check-syntax
@@ -69,7 +73,9 @@ check-syntax:
 
 .PHONY: check-unit-tests
 check-unit-tests: snap-confine-unit-tests
+if WITH_UNIT_TESTS
 	./snap-confine-unit-tests
+endif
 
 
 # Run check-syntax when checking


### PR DESCRIPTION
This removes glib2 (& sons) dependencies, useful mostly on openwrt.
