### PR TITLE
Bind mount /var/log for log-observe

### DIFF
--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -107,6 +107,7 @@
     mount options=(rw rbind) /run/ -> /tmp/snap.rootfs_*/run/,
     mount options=(rw rbind) /media/ -> /tmp/snap.rootfs_*/media/,
     mount options=(rw rbind) {/usr,}/lib/modules/ -> /tmp/snap.rootfs_*/lib/modules/,
+    mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
     # Allow to mkdir /var/lib/snapd/hostfs

--- a/spread-tests/regression/lp-1606277/task.yaml
+++ b/spread-tests/regression/lp-1606277/task.yaml
@@ -1,0 +1,17 @@
+summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1606277 
+# This is blacklisted on debian because debian doesn't use apparmor yet
+systems: [-debian-8]
+details: |
+    A missing bind mount for /var/log prevents access to system log files
+    even if the log-observe interface is being used.
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+    echo "And having connected the log-observe interface"
+    snap connect snapd-hacker-toolbelt:log-observe ubuntu-core:log-observe
+execute: |
+    echo "We can now see a non-empty /var/log directory"
+    cd /
+    /snap/bin/snapd-hacker-toolbelt.busybox ls /var/log 
+restore: |
+    snap remove snapd-hacker-toolbelt

--- a/spread-tests/regression/lp-1606277/task.yaml
+++ b/spread-tests/regression/lp-1606277/task.yaml
@@ -12,6 +12,6 @@ prepare: |
 execute: |
     echo "We can now see a non-empty /var/log directory"
     cd /
-    /snap/bin/snapd-hacker-toolbelt.busybox ls /var/log 
+    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox ls /var/log | wc -l)" != 0 ]
 restore: |
     snap remove snapd-hacker-toolbelt

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -204,6 +204,7 @@ void setup_snappy_os_mounts()
 		"/var/snap",	// to get access to global snap data
 		"/var/lib/snapd",	// to get access to snapd state and seccomp profiles
 		"/var/tmp",	// to get access to the other temporary directory
+		"/var/log",	// to get access to log files via log-observe interface
 		"/run",		// to get /run with sockets and what not
 		"/media",	// access to the users removable devices
 		"/lib/modules",	// access to the modules of the running kernel


### PR DESCRIPTION
This patch bind mounts the /var/log directory so that snaps can use the
log-observe interface to get access to system log files.

The fix also involves another permission in the apparmor profile for the
particular mount to go ahead.

The whole set is tested with a new spread regression test.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1606277
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
