### PR TITLE
Add configure option to select merged /usr FHS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,5 +116,18 @@ AS_IF([test "x$enable_nvidia_arch" = "xyes"], [
     AC_DEFINE([NVIDIA_ARCH], [1],
         [Support for propietary nvidia drivers (Arch)])])
 
+AC_ARG_ENABLE([merged-usr],
+    AS_HELP_STRING([--enable-merged-usr], [Enable support for merged /usr directory]),
+    [case "${enableval}" in
+        yes) enable_merged_usr=yes ;;
+        no)  enable_merged_usr=no ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-merged-usr])
+    esac], [enable_merged_usr=no])
+AM_CONDITIONAL([MERGED_USR], [test "x$enable_merged_usr" = "xyes"])
+
+AS_IF([test "x$enable_merged_usr" = "xyes"], [
+    AC_DEFINE([MERGED_USR], [1],
+        [Support for merged /usr directory])])
+
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile docs/Makefile])
 AC_OUTPUT

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -206,7 +206,10 @@ void setup_snappy_os_mounts()
 		"/var/tmp",	// to get access to the other temporary directory
 		"/var/log",	// to get access to log files via log-observe interface
 		"/run",		// to get /run with sockets and what not
+#ifdef MERGED_USR
+#else
 		"/media",	// access to the users removable devices
+#endif				// MERGED_USR
 		"/lib/modules",	// access to the modules of the running kernel
 	};
 	for (int i = 0; i < sizeof(source_mounts) / sizeof *source_mounts; i++) {


### PR DESCRIPTION
On some distributions the /usr directory is now "merged" into the root
filesystem. In that layout symlinks provide the typical FHS view but
some things are moved around to incompatible locations.

One of the directories affected by this is /media. In the merged FHS it
is now buried somewhere in /run. In the prior layout it is in, well,
/media itself.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
