### PR TITLE
unconditionally mount /usr/src (LP: #1597842)

### DIFF
--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -109,6 +109,7 @@
     mount options=(rw rbind) /media/ -> /tmp/snap.rootfs_*/media/,
     mount options=(rw rbind) {/usr,}/lib/modules/ -> /tmp/snap.rootfs_*/lib/modules/,
     mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
+    mount options=(rw rbind) /usr/src/ -> /tmp/snap.rootfs_*/usr/src/,
     mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
     # Allow to mkdir /var/lib/snapd/hostfs

--- a/spread-tests/mount-usr-src/task.yaml
+++ b/spread-tests/mount-usr-src/task.yaml
@@ -1,0 +1,17 @@
+summary: Check for https://bugs.launchpad.net/snap-confine/+bug/1597842
+# This is blacklisted on debian because debian doesn't use apparmor yet
+systems: [-debian-8]
+details: |
+    The snappy execution environment should contain the /usr/src directory
+    from the host filesystem when running on a classic distribution.
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+    echo "and having connected the mount-observe interface"
+    snap connect snapd-hacker-toolbelt:mount-observe ubuntu-core:mount-observe
+execute: |
+    cd /
+    echo "We can ensure that /usr/src is mounted"
+    /snap/bin/snapd-hacker-toolbelt.busybox cat /proc/self/mounts | grep ' /usr/src '
+restore: |
+    snap remove snapd-hacker-toolbelt

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -205,13 +205,14 @@ void setup_snappy_os_mounts()
 		"/var/snap",	// to get access to global snap data
 		"/var/lib/snapd",	// to get access to snapd state and seccomp profiles
 		"/var/tmp",	// to get access to the other temporary directory
-		"/var/log",	// to get access to log files via log-observe interface
 		"/run",		// to get /run with sockets and what not
 #ifdef MERGED_USR
 #else
 		"/media",	// access to the users removable devices
 #endif				// MERGED_USR
 		"/lib/modules",	// access to the modules of the running kernel
+		"/usr/src",	// FIXME: move to SecurityMounts in system-trace interface
+		"/var/log",	// FIXME: move to SecurityMounts in log-observe interface
 	};
 	for (int i = 0; i < sizeof(source_mounts) / sizeof *source_mounts; i++) {
 		const char *src = source_mounts[i];


### PR DESCRIPTION
Some snaps need access to the kernel sources. On an Ubuntu classic system these
are found in /usr/src. This does not cover other locations for cross-distro
or kernel snaps.

To unblock people, this simply mounts /usr/src with the other OS mounts, but
this should really be interface-dependent along with /var/log. Since that
requires a bit of reorganizing, https://bugs.launchpad.net/snappy/+bug/1609499
covers this work.
