### PR TITLE
Restore creation of $SNAP_USER_DATA

### DIFF
--- a/debian/usr.bin.snap-confine
+++ b/debian/usr.bin.snap-confine
@@ -155,6 +155,6 @@
     owner @{HOME}/.Private/ r,
     owner @{HOME}/.Private/** mrixwlk,
     # new-style encrypted $HOME
-    owner @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
-    owner @{HOMEDIRS}/.ecryptfs/*/.Private/** mrixwlk,
+    @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
+    @{HOMEDIRS}/.ecryptfs/*/.Private/** mrixwlk,
 }

--- a/spread-tests/regression/lp-1580018/task.yaml
+++ b/spread-tests/regression/lp-1580018/task.yaml
@@ -3,7 +3,7 @@ summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/15800
 systems: [-debian-8]
 prepare:
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap list | grep -q snapd-hacker-toolbelt || snap install snapd-hacker-toolbelt
+    snap install snapd-hacker-toolbelt
 execute: |
     cd /
     echo "We can check the inode number of /etc/alternatives" 

--- a/spread-tests/regression/lp-1580018/task.yaml
+++ b/spread-tests/regression/lp-1580018/task.yaml
@@ -1,7 +1,7 @@
 summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1580018
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
-prepare:
+prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
     snap install snapd-hacker-toolbelt
 execute: |

--- a/spread-tests/regression/lp-1580018/task.yaml
+++ b/spread-tests/regression/lp-1580018/task.yaml
@@ -1,11 +1,11 @@
 summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1580018
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
-execute: |
-    cd /
+prepare:
     echo "Having installed the snapd-hacker-toolbelt snap"
     snap list | grep -q snapd-hacker-toolbelt || snap install snapd-hacker-toolbelt
-
+execute: |
+    cd /
     echo "We can check the inode number of /etc/alternatives" 
     host_inode="$(stat -c '%i' /etc/alternatives)"
     core_inode="$(stat -c '%i' /snap/ubuntu-core/current/etc/alternatives)"
@@ -13,3 +13,5 @@ execute: |
     echo "The inode number as seen from a confined snap should be that of the /etc/alternatives from the core snap"
     [ "$host_inode" != "$core_inode" ]
     [ "$effective_inode" = "$core_inode" ]
+restore: |
+    snap remove snapd-hacker-toolbelt

--- a/spread-tests/regression/lp-1595444/task.yaml
+++ b/spread-tests/regression/lp-1595444/task.yaml
@@ -3,7 +3,7 @@ summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/15954
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap list | grep -q snapd-hacker-toolbelt || snap install snapd-hacker-toolbelt
+    snap install snapd-hacker-toolbelt
     mkdir -p "/foo"
 execute: |
     echo "We can go to a location that is available in all snaps (/tmp)"

--- a/spread-tests/user-data-dir-created/task.yaml
+++ b/spread-tests/user-data-dir-created/task.yaml
@@ -1,0 +1,23 @@
+summary: Ensure that SNAP_USER_DATA directory is created by snap-confine
+# This is blacklisted on debian because debian doesn't use apparmor yet
+systems: [-debian-8]
+details: |
+    A regression was found in snap-confine where the new code path in snapd was
+    not active yet but the corresponding code path in snap-confine was already
+    removed. This resulted in the $SNAP_USER_DATA directory not being created
+    at runtime.
+    This test checks that it is actually created
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+    echo "Having removed the $SNAP_USER_DATA directory"
+    rm -rf "$HOME/snap/snapd-hacker-toolbelt/"
+execute: |
+    cd /
+    echo "We can now run snapd-hacker-toolbelt.busybox true"
+    /snap/bin/snapd-hacker-toolbelt.busybox true
+    echo "And see that the $SNAP_USER_DATA directory was created"
+    test -d $HOME/snap/snapd-hacker-toolbelt
+restore: |
+    snap remove snapd-hacker-toolbelt
+    rm -rf "$HOME/snap/snapd-hacker-toolbelt/"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,9 @@ snap_confine_SOURCES = \
 	cleanup-funcs.c \
 	cleanup-funcs.h \
 	udev-support.c \
-	udev-support.h
+	udev-support.h \
+	user-support.c \
+	user-support.h
 
 snap_confine_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_confine_LDFLAGS = $(AM_LDFLAGS)

--- a/src/sc-main.c
+++ b/src/sc-main.c
@@ -35,6 +35,7 @@
 #endif				// ifdef HAVE_SECCOMP
 #include "udev-support.h"
 #include "cleanup-funcs.h"
+#include "user-support.h"
 
 int sc_main(int argc, char **argv)
 {
@@ -134,8 +135,10 @@ int sc_main(int argc, char **argv)
 		if (real_uid != 0 && getegid() == 0)
 			die("dropping privs did not work");
 	}
-	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
+	// Ensure that the user data path exists.
+	setup_user_data();
 
+	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
 #ifdef HAVE_APPARMOR
 	int rc = 0;
 	// set apparmor rules

--- a/src/user-support.c
+++ b/src/user-support.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+#include "user-support.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "utils.h"
+
+static void mkpath(const char *const path)
+{
+	// If asked to create an empty path, return immediately.
+	if (strlen(path) == 0) {
+		return;
+	}
+	// We're going to use strtok_r, which needs to modify the path, so
+	// we'll make a copy of it.
+	char *path_copy = strdup(path);
+	if (path_copy == NULL) {
+		die("failed to create user data directory");
+	}
+	// Open flags to use while we walk the user data path:
+	// - Don't follow symlinks
+	// - Don't allow child access to file descriptor
+	// - Only open a directory (fail otherwise)
+	int open_flags = O_NOFOLLOW | O_CLOEXEC | O_DIRECTORY;
+
+	// We're going to create each path segment via openat/mkdirat calls
+	// instead of mkdir calls, to avoid following symlinks and placing the
+	// user data directory somewhere we never intended for it to go. The
+	// first step is to get an initial file descriptor.
+	int fd = AT_FDCWD;
+	if (path_copy[0] == '/') {
+		fd = open("/", open_flags);
+		if (fd < 0) {
+			free(path_copy);
+			die("failed to create user data directory");
+		}
+	}
+	// strtok_r needs a pointer to keep track of where it is in the string.
+	char *path_walker;
+
+	// Initialize tokenizer and obtain first path segment.
+	char *path_segment = strtok_r(path_copy, "/", &path_walker);
+	while (path_segment) {
+		// Try to create the directory. It's okay if it already
+		// existed, but any other error is fatal.
+		if (mkdirat(fd, path_segment, 0755) < 0 && errno != EEXIST) {
+			close(fd);	// we die regardless of return code
+			free(path_copy);
+			die("failed to create user data directory");
+		}
+		// Open the parent directory we just made (and close the
+		// previous one) so we can continue down the path.
+		int previous_fd = fd;
+		fd = openat(fd, path_segment, open_flags);
+		if (close(previous_fd) != 0) {
+			free(path_copy);
+			die("could not close path segment");
+		}
+		if (fd < 0) {
+			free(path_copy);
+			die("failed to create user data directory");
+		}
+		// Obtain the next path segment.
+		path_segment = strtok_r(NULL, "/", &path_walker);
+	}
+
+	// Close the descriptor for the final directory in the path.
+	if (close(fd) != 0) {
+		free(path_copy);
+		die("could not close final directory");
+	}
+
+	free(path_copy);
+}
+
+void setup_user_data()
+{
+	const char *user_data = getenv("SNAP_USER_DATA");
+
+	if (user_data == NULL)
+		return;
+	// Only support absolute paths.
+	if (user_data[0] != '/') {
+		die("user data directory must be an absolute path");
+	}
+
+	mkpath(user_data);
+}

--- a/src/user-support.h
+++ b/src/user-support.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_USER_SUPPORT_H
+#define SNAP_CONFINE_USER_SUPPORT_H
+
+void setup_user_data();
+
+#endif


### PR DESCRIPTION
This patch restores creation of SNAP_USER_DATA directory. This was a regression of functionality that occurred because the new code path in snapd that does the same thing is not active yet (it depends on snap-exec).

The fix comes with spread tests that should reliably work even when snap-exec is in use.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1612120
