### PR TITLE
Move apparmor profile for snap-confine to src/

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,5 +25,5 @@ override_dh_fixperms:
 	dh_fixperms -Xusr/lib/snapd/snap-confine
 
 override_dh_installdeb:
-	dh_apparmor --profile-name=usr.bin.snap-confine -psnap-confine
+	dh_apparmor --profile-name=usr.lib.snapd.snap-confine -psnap-confine
 	dh_installdeb

--- a/debian/snap-confine.install
+++ b/debian/snap-confine.install
@@ -1,3 +1,3 @@
-debian/usr.bin.snap-confine etc/apparmor.d
+etc/apparmor.d/*.snap-confine
 lib/*
 usr/lib/snapd/*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,15 +83,23 @@ fmt:
 	       indent -linux "$$f"; \
 	done;
 
-EXTRA_DIST = 80-snappy-assign.rules snappy-app-dev
+EXTRA_DIST = 80-snappy-assign.rules snappy-app-dev snap-confine.apparmor.in
+
+snap-confine.apparmor: snap-confine.apparmor.in Makefile
+	sed -e 's,[@]LIBEXECDIR[@],$(libexecdir),g' <$< >$@
 
 # NOTE: This makes distcheck fail but it is required for udev, so go figure.
 # http://www.gnu.org/software/automake/manual/automake.html#Hard_002dCoded-Install-Paths
 #
-# Install udev rules
-install-data-local:
+# Install udev rules and the apparmor profile
+#
+# NOTE: the funky make functions here just convert /foo/bar/froz into foo.bar.froz
+# The inner subst replaces slashes with dots and the outer patsubst strips the leading dot
+install-data-local: snap-confine.apparmor
 	install -d -m 755 $(DESTDIR)$(shell pkg-config udev --variable=udevdir)/rules.d
 	install -m 644 $(srcdir)/80-snappy-assign.rules $(DESTDIR)$(shell pkg-config udev --variable=udevdir)/rules.d
+	install -d -m 755 $(DESTDIR)/etc/apparmor.d/
+	install -m 644 snap-confine.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine
 
 # Install support script for udev rules
 install-exec-local:

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -1,7 +1,7 @@
 # Author: Jamie Strandboge <jamie@canonical.com>
 #include <tunables/global>
 
-/usr/lib/snapd/snap-confine (attach_disconnected) {
+@LIBEXECDIR@/snap-confine (attach_disconnected) {
     # We run privileged, so be fanatical about what we include and don't use
     # any abstractions
     /etc/ld.so.cache r,
@@ -17,7 +17,7 @@
     /usr/lib/@{multiarch}/libseccomp.so* mr,
     /lib/@{multiarch}/libseccomp.so* mr,
 
-    /usr/lib/snapd/snap-confine r,
+    @LIBEXECDIR@/snap-confine r,
 
     /dev/null rw,
     /dev/full rw,


### PR DESCRIPTION
This patch takes the apparmor profile for snap-confine itself out of the
debian/ directory and into the src/ directory.

In addition, the profile is now generated to understand build-time
configuration as it has to match the final location of the installed
snap-confine executable.

Lastly the name of the profile in the tree is snap-confine.apparmor.in
which is changed on install time to the apparmor-style
usr.lib.snapd.snap-confine (the actual name depends on libexecdir).

This patch paves the way for the upcoming removal of debian/ from the
upstream repository and integration of downstream packaging into spread
tests.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
