### PR TITLE
Disable owner checks for 14.04-style private home

### DIFF
--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -152,8 +152,8 @@
     # Workaround https://launchpad.net/bugs/359338 until upstream handles
     # stacked filesystems generally.
     # encrypted ~/.Private and old-style encrypted $HOME
-    owner @{HOME}/.Private/ r,
-    owner @{HOME}/.Private/** mrixwlk,
+    @{HOME}/.Private/ r,
+    @{HOME}/.Private/** mrixwlk,
     # new-style encrypted $HOME
     @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
     @{HOMEDIRS}/.ecryptfs/*/.Private/** mrixwlk,


### PR DESCRIPTION
This patch is a follow-up on the earlier work that allowed snap-confine
to access encrypted home directory even if invoked as another user (e.g.
sudo). Encrypted home directory support has evolved over time and the
patch applied earlier only covered the most recent implementation of the
concept. This patch discards owner checks for older implementations.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
