### PR TITLE
Move to /var/lib/snapd/void instead of aborting

### DIFF
--- a/spread-tests/regression/lp-1595444/task.yaml
+++ b/spread-tests/regression/lp-1595444/task.yaml
@@ -1,6 +1,9 @@
 summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1595444
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
+details: |
+    This task checks the behavior of snap-confine when it is started from
+    a directory that doesn't exist in the execution environment (chroot).
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
     snap install snapd-hacker-toolbelt
@@ -10,14 +13,10 @@ execute: |
     echo "We can run the 'cwd' tool from busybox and it reports /tmp" 
     [ "$(cd /tmp && /snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "/tmp" ]
     echo "But if we go to a location that is not available to snaps (e.g. /foo)"
-    echo "Then the same 'cwd' tool refuses to run the snap"
-    cd "/foo" || exit 1
-    # pwd doesn't run
-    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "" ]
-    # there's an accurate error message
-    [ "$(/snap/bin/snapd-hacker-toolbelt.busybox pwd 2>&1)" = "cannot remain in /foo, please run this snap from another location. errmsg: No such file or directory" ]
-    # snap-confine returns an error code on exit
-    ! /snap/bin/snapd-hacker-toolbelt.busybox pwd
+    echo "Then snap-confine moves us to /var/lib/snapd/void"
+    [ "$(cd /foo && /snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "/var/lib/snapd/void" ]
+    echo "And that directory is not readable or writable"
+    [ "$(cd /foo && /snap/bin/snapd-hacker-toolbelt.busybox ls 2>&1)" = "ls: can't open '.': Permission denied" ];
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -103,11 +103,14 @@ snap-confine.apparmor: snap-confine.apparmor.in Makefile
 #
 # NOTE: the funky make functions here just convert /foo/bar/froz into foo.bar.froz
 # The inner subst replaces slashes with dots and the outer patsubst strips the leading dot
+#
+# NOTE: The 'void' directory *has to* be chmod 000
 install-data-local: snap-confine.apparmor
 	install -d -m 755 $(DESTDIR)$(shell pkg-config udev --variable=udevdir)/rules.d
 	install -m 644 $(srcdir)/80-snappy-assign.rules $(DESTDIR)$(shell pkg-config udev --variable=udevdir)/rules.d
 	install -d -m 755 $(DESTDIR)/etc/apparmor.d/
 	install -m 644 snap-confine.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine
+	install -d -m 000 $(DESTDIR)/var/lib/snapd/void
 
 # Install support script for udev rules
 install-exec-local:

--- a/src/sc-main.c
+++ b/src/sc-main.c
@@ -121,7 +121,14 @@ int sc_main(int argc, char **argv)
 		// Try to re-locate back to vanilla working directory. This can fail
 		// because that directory is no longer present.
 		if (chdir(vanilla_cwd) != 0) {
-			die("cannot remain in %s, please run this snap from another location", vanilla_cwd);
+			debug
+			    ("cannot remain in %s, moving to the void directory",
+			     vanilla_cwd);
+			if (chdir(SC_VOID_DIR) != 0) {
+				die("cannot change directory to %s",
+				    SC_VOID_DIR);
+			}
+			debug("successfully moved to %s", SC_VOID_DIR);
 		}
 		// the rest does not so temporarily drop privs back to calling
 		// user (we'll permanently drop after loading seccomp)

--- a/src/sc-main.h
+++ b/src/sc-main.h
@@ -18,6 +18,12 @@
 #ifndef SNAP_CONFINE_MAIN
 #define SNAP_CONFINE_MAIN
 
+/*! The void directory.
+ *  Snap confine moves to that directory in case it cannot retain
+ *  the current working directory across the pivot_root call.
+ **/
+#define SC_VOID_DIR "/var/lib/snapd/void"
+
 int sc_main(int argc, char **argv);
 
 #endif				// SNAP_CONFINE_MAIN


### PR DESCRIPTION
This patch changes snap-confine behavior when the current working
directory cannot be preserved. In the past, when it was not possible to
restore the working directory after chrooting into the core snap,
snap-confine would fail with an error message.

This behavior was hard to understand so instead snap-confine will now
chdir to /var/lib/snapd/void. This directory is "chmod 0" so that for
commands that care about the current working directory, they will see
permission denied errors. This is more naturally in line with what users
would expect.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
