### PR TITLE
Add quirk for /var/lib/lxd

### DIFF
--- a/spread-tests/regression/lp-1613845/task.yaml
+++ b/spread-tests/regression/lp-1613845/task.yaml
@@ -1,0 +1,22 @@
+summary: Check that /var/lib/lxd is bind mounted to the real thing if one exists
+# This is blacklisted on debian because we first have to get the dpkg-vendor patches
+systems: [-debian-8]
+details: |
+    After switching to the chroot-based snap-confine the LXD snap stopped
+    working (even in devmode) because it relied on access to /var/lib/lxd from
+    the host filesystem. While this would never work in an all-snap image it is
+    still important to ensure that it works in classic devmode environment.
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap in devmode"
+    snap install --devmode snapd-hacker-toolbelt
+    echo "Having created a canary file in /var/lib/lxd"
+    mkdir -p /var/lib/lxd
+    echo "test" > /var/lib/lxd/canary
+execute: |
+    cd /
+    echo "We can see the canary file in /var/lib/lxd"
+    [ "$(snapd-hacker-toolbelt.busybox cat /var/lib/lxd/canary)" = "test" ]
+restore: |
+    snap remove snapd-hacker-toolbelt
+    rm -f /var/lib/lxd/canary
+    rmdir /var/lib/lxd

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,9 @@ snap_confine_SOURCES = \
 	udev-support.c \
 	udev-support.h \
 	user-support.c \
-	user-support.h
+	user-support.h \
+	quirks.c \
+	quirks.h
 
 snap_confine_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_confine_LDFLAGS = $(AM_LDFLAGS)

--- a/src/cleanup-funcs.h
+++ b/src/cleanup-funcs.h
@@ -27,6 +27,8 @@
 #ifdef HAVE_SECCOMP
 #include <seccomp.h>
 #endif				// HAVE_SECCOMP
+#include <sys/types.h>
+#include <dirent.h>
 
 /**
  * Free a dynamically allocated string.
@@ -61,5 +63,13 @@ void sc_cleanup_endmntent(FILE ** ptr);
  **/
 void sc_cleanup_seccomp_release(scmp_filter_ctx * ptr);
 #endif				// HAVE_SECCOMP
+
+/**
+ * Close an open directory with closedir(3)
+ *
+ * This function is designed to be used with
+ * __attribute__((cleanup(sc_cleanup_closedir))).
+ **/
+void sc_cleanup_closedir(DIR ** ptr);
 
 #endif

--- a/src/quirks.c
+++ b/src/quirks.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+#include "quirks.h"
+
+#include <dirent.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "utils.h"
+#include "cleanup-funcs.h"
+#include "classic.h"
+// XXX: for smaller patch, this should be in utils.h later
+#include "user-support.h"
+
+/**
+ * Mount a tmpfs at a given directory.
+ *
+ * The empty tmpfs is used as a substrate to create additional directories and
+ * then bind mounts to other destinations.
+ *
+ * It is useful to poke unexpected holes in the read-only core snap.
+ **/
+static void sc_quirk_setup_tmpfs(const char *dirname)
+{
+	debug("mounting tmpfs at %s", dirname);
+	if (mount("none", dirname, "tmpfs", MS_NODEV | MS_NOSUID, NULL) != 0) {
+		die("cannot mount tmpfs at %s", dirname);
+	};
+}
+
+/**
+ * Create an empty directory and bind mount something there.
+ *
+ * The empty directory is created at destdir. The bind mount is
+ * done from srcdir to destdir. The bind mount is performed with
+ * caller-defined flags.
+ **/
+static void sc_quirk_mkdir_bind(const char *src_dir, const char *dest_dir,
+				unsigned flags)
+{
+	flags |= MS_BIND;
+	debug("creating empty directory at %s", dest_dir);
+	mkpath(dest_dir);
+	debug("bind mounting %s -> %s with flags %#x", src_dir, dest_dir,
+	      flags);
+	if (mount(src_dir, dest_dir, NULL, flags, NULL) != 0) {
+		die("cannot bind mount %s -> %s with flags %#x", src_dir,
+		    dest_dir, flags);
+	}
+}
+
+/**
+ * Create a writable mimic directory based on reference directory.
+ *
+ * The mimic directory is a tmpfs populated with bind mounts to the (possibly
+ * read only) directories in the reference directory. While all the read-only
+ * content stays read-only the actual mimic directory is writable so additional
+ * content can be placed there.
+ *
+ * Flags are forwarded to sc_quirk_mkdir_bind()
+ **/
+static void sc_quirk_create_writable_mimic(const char *mimic_dir,
+					   const char *ref_dir, unsigned flags)
+{
+	debug("creating writable mimic directory %s based on %s", mimic_dir,
+	      ref_dir);
+	sc_quirk_setup_tmpfs(mimic_dir);
+	debug("bind-mounting all the files from the reference directory");
+	DIR *dirp __attribute__ ((cleanup(sc_cleanup_closedir))) = NULL;
+	dirp = opendir(ref_dir);
+	if (dirp == NULL) {
+		die("cannot open reference directory %s", ref_dir);
+	}
+	struct dirent entry, *entryp = NULL;
+	do {
+		char src_name[PATH_MAX * 2];
+		char dest_name[PATH_MAX * 2];
+		if (readdir_r(dirp, &entry, &entryp) != 0) {
+			die("cannot read another directory entry");
+		}
+		if (entryp == NULL) {
+			break;
+		}
+		if (strcmp(entryp->d_name, ".") == 0
+		    || strcmp(entryp->d_name, "..") == 0) {
+			continue;
+		}
+		if (entryp->d_type != DT_DIR && entryp->d_type != DT_REG) {
+			die("unsupported entry type of file %s (%d)",
+			    entryp->d_name, entryp->d_type);
+		}
+		must_snprintf(src_name, sizeof src_name, "%s/%s", ref_dir,
+			      entryp->d_name);
+		must_snprintf(dest_name, sizeof dest_name, "%s/%s", mimic_dir,
+			      entryp->d_name);
+		sc_quirk_mkdir_bind(src_name, dest_name, flags);
+	} while (entryp != NULL);
+}
+
+/**
+ * Setup a quirk for LXD.
+ *
+ * An existing LXD snap relies on pre-chroot behavior to access /var/lib/lxd
+ * while in devmode. Since that directory doesn't exist in the core snap the
+ * quirk punches a custom hole so that this directory shows the hostfs content
+ * if such directory exists on the host.
+ *
+ * See: https://bugs.launchpad.net/snap-confine/+bug/1613845
+ **/
+static void sc_setup_lxd_quirk()
+{
+	const char *hostfs_lxd_dir = SC_HOSTFS_DIR "/var/lib/lxd";
+	const char *lxd_dir = "/var/lib/lxd";
+	if (access(hostfs_lxd_dir, F_OK) == 0) {
+		debug("setting up quirk for LXD (see LP: #1613845)");
+		sc_quirk_mkdir_bind(hostfs_lxd_dir, lxd_dir,
+				    MS_REC | MS_SLAVE | MS_NODEV | MS_NOSUID |
+				    MS_NOEXEC);
+	}
+}
+
+void sc_setup_quirks()
+{
+	// because /var/lib/snapd is essential let's move it to /tmp/snapd for a sec
+	char snapd_tmp[] = "/tmp/snapd.quirks_XXXXXX";
+	if (mkdtemp(snapd_tmp) == 0) {
+		die("cannot create temporary directory for /var/lib/snapd mount point");
+	}
+	if (mount("/var/lib/snapd", snapd_tmp, NULL, MS_MOVE, NULL)
+	    != 0) {
+		die("cannot move /var/lib/snapd to %s", snapd_tmp);
+	}
+	// now let's make /var/lib the vanilla /var/lib from the core snap
+	sc_quirk_create_writable_mimic("/var/lib",
+				       "/snap/ubuntu-core/current/var/lib",
+				       MS_RDONLY | MS_REC | MS_SLAVE | MS_NODEV
+				       | MS_NOSUID);
+	// now let's move /var/lib/snapd (that was originally there) back
+	if (umount("/var/lib/snapd") != 0) {
+		die("cannot unmount /var/lib/snapd");
+	}
+	if (mount(snapd_tmp, "/var/lib/snapd", NULL, MS_MOVE, NULL)
+	    != 0) {
+		die("cannot move %s to /var/lib/snapd", snapd_tmp);
+	}
+	if (rmdir(snapd_tmp) != 0) {
+		die("cannot remove %s", snapd_tmp);
+	}
+	// We are now ready to apply any quirks that relate to /var/lib
+	sc_setup_lxd_quirk();
+}

--- a/src/quirks.h
+++ b/src/quirks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -15,37 +15,16 @@
  *
  */
 
-#include "cleanup-funcs.h"
+#ifndef SNAP_QUIRKS_H
+#define SNAP_QUIRKS_H
 
-#include <mntent.h>
+/**
+ * Setup various quirks that have to exists for now.
+ *
+ * This function applies non-standard tweaks that are required
+ * because of requirement to stay compatible with certain snaps
+ * that were tested with pre-chroot layout.
+ **/
+void sc_setup_quirks();
 
-void sc_cleanup_string(char **ptr)
-{
-	free(*ptr);
-}
-
-void sc_cleanup_file(FILE ** ptr)
-{
-	if (*ptr != NULL)
-		fclose(*ptr);
-}
-
-void sc_cleanup_endmntent(FILE ** ptr)
-{
-	if (*ptr != NULL)
-		endmntent(*ptr);
-}
-
-#ifdef HAVE_SECCOMP
-void sc_cleanup_seccomp_release(scmp_filter_ctx * ptr)
-{
-	seccomp_release(*ptr);
-}
-#endif				// HAVE_SECCOMP
-
-void sc_cleanup_closedir(DIR ** ptr)
-{
-	if (*ptr != NULL) {
-		closedir(*ptr);
-	}
-}
+#endif

--- a/src/sc-main.c
+++ b/src/sc-main.c
@@ -36,6 +36,7 @@
 #include "udev-support.h"
 #include "cleanup-funcs.h"
 #include "user-support.h"
+#include "quirks.h"
 
 int sc_main(int argc, char **argv)
 {
@@ -108,6 +109,9 @@ int sc_main(int argc, char **argv)
 
 		// set up private /dev/pts
 		setup_private_pts();
+
+		// setup quirks for specific snaps
+		sc_setup_quirks();
 
 		// this needs to happen as root
 		struct snappy_udev udev_s;

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -160,4 +160,21 @@
     # new-style encrypted $HOME
     @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
     @{HOMEDIRS}/.ecryptfs/*/.Private/** mrixwlk,
+
+    # Support for the quirk system
+    /var/ r,
+    /var/lib/ r,
+    /var/lib/** rw,
+    /tmp/ r,
+    /tmp/snapd.quirks_*/ rw,
+    mount options=(move) /var/lib/snapd/ -> /tmp/snapd.quirks_*/,
+    mount fstype=tmpfs options=(rw nodev nosuid) none -> /var/lib/,
+    mount options=(ro rbind) /snap/ubuntu-core/*/var/lib/** -> /var/lib/**,
+    umount /var/lib/snapd/,
+    mount options=(move) /tmp/snapd.quirks_*/ -> /var/lib/snapd/,
+
+    # support for the LXD quirk
+    mount options=(rw rbind nodev nosuid noexec) /var/lib/snapd/hostfs/var/lib/lxd/ -> /var/lib/lxd/,
+    /var/lib/lxd/ w,
+    /var/lib/snapd/hostfs/var/lib/lxd r,
 }

--- a/src/user-support.c
+++ b/src/user-support.c
@@ -27,7 +27,8 @@
 
 #include "utils.h"
 
-static void mkpath(const char *const path)
+// TODO: rename and move to utils.h
+void mkpath(const char *const path)
 {
 	// If asked to create an empty path, return immediately.
 	if (strlen(path) == 0) {

--- a/src/user-support.h
+++ b/src/user-support.h
@@ -19,5 +19,6 @@
 #define SNAP_CONFINE_USER_SUPPORT_H
 
 void setup_user_data();
+void mkpath(const char *const path);
 
 #endif


### PR DESCRIPTION
This patch adds a quirk that ensures /var/lib/lxd is bind mounted from
the hostfs if such directory is available there.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1613845
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
