### PR TITLE
Improve support for 14.04

### DIFF
--- a/spread-tests/distros/ubuntu.common
+++ b/spread-tests/distros/ubuntu.common
@@ -1,3 +1,3 @@
 distro_archive=http://archive.ubuntu.com/ubuntu
 distro_packaging_git=https://git.launchpad.net/snap-confine
-sbuild_args="--extra-repository=deb http://archive.ubuntu.com/ubuntu/ ${distro_codename} universe" 
+sbuild_createchroot_extra="--components=main,universe"


### PR DESCRIPTION
This patch improves spread support for 14.04;

Currently we cannot yet enable 14.04 support because snapd is not available yet. With this patch though that is the only remaining blocker.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
