### PR TITLE
Account for trusty in apparmor setup.

### DIFF
--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -13,6 +13,10 @@
     /lib/@{multiarch}/libgcc_s.so* mr,
     # normal libs in order
     /lib/@{multiarch}/libapparmor.so* mr,
+    /lib/@{multiarch}/libcgmanager.so* mr,
+    /lib/@{multiarch}/libnih.so* mr,
+    /lib/@{multiarch}/libnih-dbus.so* mr,
+    /lib/@{multiarch}/libdbus-1.so* mr,
     /lib/@{multiarch}/libudev.so* mr,
     /usr/lib/@{multiarch}/libseccomp.so* mr,
     /lib/@{multiarch}/libseccomp.so* mr,


### PR DESCRIPTION
```
ubuntu@ubuntu:~$ ldd /usr/bin/ubuntu-core-launcher 
    linux-vdso.so.1 =>  (0x00007fff41de0000)
    libudev.so.1 => /lib/x86_64-linux-gnu/libudev.so.1 (0x00007f13f296f000)
    libseccomp.so.2 => /lib/x86_64-linux-gnu/libseccomp.so.2 (0x00007f13f2731000)
    libapparmor.so.1 => /lib/x86_64-linux-gnu/libapparmor.so.1 (0x00007f13f2520000)
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f13f215b000)
    libcgmanager.so.0 => /lib/x86_64-linux-gnu/libcgmanager.so.0 (0x00007f13f1f40000)
    libnih.so.1 => /lib/x86_64-linux-gnu/libnih.so.1 (0x00007f13f1d27000)
    libnih-dbus.so.1 => /lib/x86_64-linux-gnu/libnih-dbus.so.1 (0x00007f13f1b1d000)
    libdbus-1.so.3 => /lib/x86_64-linux-gnu/libdbus-1.so.3 (0x00007f13f18d8000)
    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f13f16cf000)
    /lib64/ld-linux-x86-64.so.2 (0x000055d10d653000)
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f13f14b1000)
```
