### PR TITLE
Make snap mount directory configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,5 +141,12 @@ AS_IF([test "x$enable_merged_usr" = "xyes"], [
     AC_DEFINE([MERGED_USR], [1],
         [Support for merged /usr directory])])
 
+SNAP_MOUNT_DIR="/snap"
+AC_ARG_WITH([snap-mount-dir],
+    AS_HELP_STRING([--with-snap-mount-dir=DIR], [Use an alternate snap mount directory]),
+    [SNAP_MOUNT_DIR="$withval"])
+AC_SUBST(SNAP_MOUNT_DIR)
+AC_DEFINE_UNQUOTED([SNAP_MOUNT_DIR], "${SNAP_MOUNT_DIR}", [Location of the snap mount points])
+
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile docs/Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -96,7 +96,7 @@ fmt:
 EXTRA_DIST = 80-snappy-assign.rules snappy-app-dev snap-confine.apparmor.in
 
 snap-confine.apparmor: snap-confine.apparmor.in Makefile
-	sed -e 's,[@]LIBEXECDIR[@],$(libexecdir),g' <$< >$@
+	sed -e 's,[@]LIBEXECDIR[@],$(libexecdir),g' -e 's,[@]SNAP_MOUNT_DIR[@],$(SNAP_MOUNT_DIR),' <$< >$@
 
 # NOTE: This makes distcheck fail but it is required for udev, so go figure.
 # http://www.gnu.org/software/automake/manual/automake.html#Hard_002dCoded-Install-Paths

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -94,19 +94,21 @@
 
     # for running snaps on classic
     mount options=(rw rslave) -> /,
-    /{tmp/snap.rootfs_*,}snap/ r,
-    /{tmp/snap.rootfs_*,}snap/** r,
+    /tmp/snap.rootfs_*/snap/ r,
+    /tmp/snap.rootfs_*/snap/** r,
+    @SNAP_MOUNT_DIR@/ r,
+    @SNAP_MOUNT_DIR@/** r,
 
     # mount calls to setup the pivot_root based chroot with the core snap as
     # the root filesystem.
-    mount options=(rw bind) /snap/ubuntu-core/*/ -> /tmp/snap.rootfs_*/,
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/ubuntu-core/*/ -> /tmp/snap.rootfs_*/,
 
     mount options=(rw rbind) /dev/ -> /tmp/snap.rootfs_*/dev/,
     mount options=(rw rbind) /etc/ -> /tmp/snap.rootfs_*/etc/,
     mount options=(rw rbind) /home/ -> /tmp/snap.rootfs_*/home/,
     mount options=(rw rbind) /root/ -> /tmp/snap.rootfs_*/root/,
     mount options=(rw rbind) /proc/ -> /tmp/snap.rootfs_*/proc/,
-    mount options=(rw rbind) /snap/ -> /tmp/snap.rootfs_*/snap/,
+    mount options=(rw rbind) @SNAP_MOUNT_DIR@/ -> /tmp/snap.rootfs_*/snap/,
     mount options=(rw rbind) /sys/ -> /tmp/snap.rootfs_*/sys/,
     mount options=(rw rbind) /tmp/ -> /tmp/snap.rootfs_*/tmp/,
     mount options=(rw rbind) /var/lib/snapd/ -> /tmp/snap.rootfs_*/var/lib/snapd/,
@@ -117,12 +119,15 @@
     mount options=(rw rbind) {/usr,}/lib/modules/ -> /tmp/snap.rootfs_*/lib/modules/,
     mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
     mount options=(rw rbind) /usr/src/ -> /tmp/snap.rootfs_*/usr/src/,
-    mount options=(rw bind) /snap/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
     # Allow to mkdir /var/lib/snapd/hostfs
     /var/lib/snapd/hostfs/ rw,
     # Allow to mount / as hostfs in the chroot
     mount options=(ro bind) / -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
+
+    # NOTE: at this stage the /snap directory is stable as we have called
+    # pivot_root already.
 
     # Support mount profiles via the content interface
     mount options=(rw bind) /snap/*/** -> /snap/*/*/**,


### PR DESCRIPTION
This patch adds the configuration option --with-snap-mount-dir that
can change the default /snap directory to another location. The code
has been tweaked to respect the new macro SNAP_MOUNT_DIR as well as
to treat /snap bind mount specially.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
