### PR TITLE
Allow the use of capabilities over setuid bit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,5 +148,18 @@ AC_ARG_WITH([snap-mount-dir],
 AC_SUBST(SNAP_MOUNT_DIR)
 AC_DEFINE_UNQUOTED([SNAP_MOUNT_DIR], "${SNAP_MOUNT_DIR}", [Location of the snap mount points])
 
+AC_ARG_ENABLE([caps-over-setuid],
+    AS_HELP_STRING([--enable-caps-over-setuid], [Use capabilities rather than setuid bit]),
+    [case "${enableval}" in
+        yes) enable_caps_over_setuid=yes ;;
+        no)  enable_caps_over_setuid=no ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-caps-over-setuid])
+    esac], [enable_caps_over_setuid=no])
+AM_CONDITIONAL([CAPS_OVER_SETUID], [test "x$enable_caps_over_setuid" = "xyes"])
+
+AS_IF([test "x$enable_caps_over_setuid" = "xyes"], [
+    AC_DEFINE([CAPS_OVER_SETUID], [1],
+        [Use capabilities rather than setuid bit])])
+
 AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile docs/Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,8 +119,13 @@ install-exec-local:
 	install -d -m 755 $(DESTDIR)$(shell pkg-config udev --variable=udevdir)
 	install -m 755 $(srcdir)/snappy-app-dev $(DESTDIR)$(shell pkg-config udev --variable=udevdir)
 
-# Ensure that snap-confine is +s (setuid)
 install-exec-hook:
+if CAPS_OVER_SETUID
+# Ensure that snap-confine has CAP_SYS_ADMIN capabilitiy
+	setcap cap_sys_admin=pe $(DESTDIR)$(libexecdir)/snap-confine
+else
+# Ensure that snap-confine is +s (setuid)
 	chmod 4755 $(DESTDIR)$(libexecdir)/snap-confine
+endif
 	install -d -m 755 $(DESTDIR)$(bindir)
 	ln -sf $(libexecdir)/snap-confine $(DESTDIR)$(bindir)/ubuntu-core-launcher

--- a/src/sc-main.c
+++ b/src/sc-main.c
@@ -66,11 +66,13 @@ int sc_main(int argc, char **argv)
 	if (!verify_security_tag(security_tag))
 		die("security tag %s not allowed", security_tag);
 
+#ifndef CAPS_OVER_SETUID
 	// this code always needs to run as root for the cgroup/udev setup,
 	// however for the tests we allow it to run as non-root
 	if (geteuid() != 0 && secure_getenv("SNAP_CONFINE_NO_ROOT") == NULL) {
 		die("need to run as root or suid");
 	}
+#endif
 #ifdef HAVE_SECCOMP
 	scmp_filter_ctx seccomp_ctx
 	    __attribute__ ((cleanup(sc_cleanup_seccomp_release))) = NULL;


### PR DESCRIPTION
This patch adds a build-time configuration option
"--enable-caps-over-setuid" that allows distributors that wish to use
filesystem capabilities to do that instead of using setuid root
executables.

The actual change disables a fragment that checked if the user runs as
root and tweaks installation. It got minimal testing on Fedora 24.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1615610
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
