### PR TITLE
Add mountinfo module

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,8 +60,7 @@ snap_confine_unit_tests_SOURCES = \
 	cleanup-funcs-test.c \
 	mount-support-test.c \
 	verify-executable-name-test.c \
-	mountinfo.c \
-	mountinfo.h
+	mountinfo-test.c
 snap_confine_unit_tests_CFLAGS = $(snap_confine_CFLAGS) $(GLIB_CFLAGS)
 snap_confine_unit_tests_LDADD = $(snap_confine_LDADD) $(GLIB_LIBS)
 snap_confine_unit_tests_LDFLAGS = $(snap_confine_LDFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,9 @@ snap_confine_SOURCES = \
 	user-support.c \
 	user-support.h \
 	quirks.c \
-	quirks.h
+	quirks.h \
+	mountinfo.c \
+	mountinfo.h
 
 snap_confine_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_confine_LDFLAGS = $(AM_LDFLAGS)
@@ -57,7 +59,9 @@ snap_confine_unit_tests_SOURCES = \
 	utils-test.c \
 	cleanup-funcs-test.c \
 	mount-support-test.c \
-	verify-executable-name-test.c
+	verify-executable-name-test.c \
+	mountinfo.c \
+	mountinfo.h
 snap_confine_unit_tests_CFLAGS = $(snap_confine_CFLAGS) $(GLIB_CFLAGS)
 snap_confine_unit_tests_LDADD = $(snap_confine_LDADD) $(GLIB_LIBS)
 snap_confine_unit_tests_LDFLAGS = $(snap_confine_LDFLAGS)

--- a/src/mountinfo-test.c
+++ b/src/mountinfo-test.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mountinfo.h"
+#include "mountinfo.c"
+
+#include <glib.h>
+
+static void test_parse_mountinfo_entry__sysfs()
+{
+	const char *line =
+	    "19 25 0:18 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw";
+	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	g_assert_nonnull(entry);
+	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_assert_cmpint(entry->mount_id, ==, 19);
+	g_assert_cmpint(entry->parent_id, ==, 25);
+	g_assert_cmpint(entry->dev_major, ==, 0);
+	g_assert_cmpint(entry->dev_minor, ==, 18);
+	g_assert_cmpstr(entry->root, ==, "/");
+	g_assert_cmpstr(entry->mount_dir, ==, "/sys");
+	g_assert_cmpstr(entry->mount_opts, ==,
+			"rw,nosuid,nodev,noexec,relatime");
+	g_assert_cmpstr(entry->optional_fields, ==, "shared:7");
+	g_assert_cmpstr(entry->fs_type, ==, "sysfs");
+	g_assert_cmpstr(entry->mount_source, ==, "sysfs");
+	g_assert_cmpstr(entry->super_opts, ==, "rw");
+	g_assert_null(entry->next);
+}
+
+// Parse the /run/snapd/ns bind mount (over itself)
+// Note that /run is itself a tmpfs mount point.
+static void test_parse_mountinfo_entry__snapd_ns()
+{
+	const char *line =
+	    "104 23 0:19 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=99840k,mode=755";
+	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	g_assert_nonnull(entry);
+	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_assert_cmpint(entry->mount_id, ==, 104);
+	g_assert_cmpint(entry->parent_id, ==, 23);
+	g_assert_cmpint(entry->dev_major, ==, 0);
+	g_assert_cmpint(entry->dev_minor, ==, 19);
+	g_assert_cmpstr(entry->root, ==, "/snapd/ns");
+	g_assert_cmpstr(entry->mount_dir, ==, "/run/snapd/ns");
+	g_assert_cmpstr(entry->mount_opts, ==, "rw,nosuid,noexec,relatime");
+	g_assert_cmpstr(entry->optional_fields, ==, "");
+	g_assert_cmpstr(entry->fs_type, ==, "tmpfs");
+	g_assert_cmpstr(entry->mount_source, ==, "tmpfs");
+	g_assert_cmpstr(entry->super_opts, ==, "rw,size=99840k,mode=755");
+	g_assert_null(entry->next);
+}
+
+static void test_parse_mountinfo_entry__snapd_mnt()
+{
+	const char *line =
+	    "256 104 0:3 mnt:[4026532509] /run/snapd/ns/hello-world.mnt rw - nsfs nsfs rw";
+	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	g_assert_nonnull(entry);
+	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_assert_cmpint(entry->mount_id, ==, 256);
+	g_assert_cmpint(entry->parent_id, ==, 104);
+	g_assert_cmpint(entry->dev_major, ==, 0);
+	g_assert_cmpint(entry->dev_minor, ==, 3);
+	g_assert_cmpstr(entry->root, ==, "mnt:[4026532509]");
+	g_assert_cmpstr(entry->mount_dir, ==, "/run/snapd/ns/hello-world.mnt");
+	g_assert_cmpstr(entry->mount_opts, ==, "rw");
+	g_assert_cmpstr(entry->optional_fields, ==, "");
+	g_assert_cmpstr(entry->fs_type, ==, "nsfs");
+	g_assert_cmpstr(entry->mount_source, ==, "nsfs");
+	g_assert_cmpstr(entry->super_opts, ==, "rw");
+	g_assert_null(entry->next);
+}
+
+static void __attribute__ ((constructor)) init()
+{
+	g_test_add_func("/mountinfo/parse_mountinfo_entry/sysfs",
+			test_parse_mountinfo_entry__sysfs);
+	g_test_add_func("/mountinfo/parse_mountinfo_entry/snapd-ns",
+			test_parse_mountinfo_entry__snapd_ns);
+	g_test_add_func("/mountinfo/parse_mountinfo_entry/snapd-mnt",
+			test_parse_mountinfo_entry__snapd_mnt);
+}

--- a/src/mountinfo-test.c
+++ b/src/mountinfo-test.c
@@ -93,6 +93,69 @@ static void test_parse_mountinfo_entry__garbage()
 	g_assert_null(entry);
 }
 
+static void test_parse_mountinfo_entry__no_tags()
+{
+	const char *line =
+	    "1 2 3:4 root mount-dir mount-opts - fs-type mount-source super-opts";
+	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	g_assert_nonnull(entry);
+	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_assert_cmpint(entry->mount_id, ==, 1);
+	g_assert_cmpint(entry->parent_id, ==, 2);
+	g_assert_cmpint(entry->dev_major, ==, 3);
+	g_assert_cmpint(entry->dev_minor, ==, 4);
+	g_assert_cmpstr(entry->root, ==, "root");
+	g_assert_cmpstr(entry->mount_dir, ==, "mount-dir");
+	g_assert_cmpstr(entry->mount_opts, ==, "mount-opts");
+	g_assert_cmpstr(entry->optional_fields, ==, "");
+	g_assert_cmpstr(entry->fs_type, ==, "fs-type");
+	g_assert_cmpstr(entry->mount_source, ==, "mount-source");
+	g_assert_cmpstr(entry->super_opts, ==, "super-opts");
+	g_assert_null(entry->next);
+}
+
+static void test_parse_mountinfo_entry__one_tag()
+{
+	const char *line =
+	    "1 2 3:4 root mount-dir mount-opts tag:1 - fs-type mount-source super-opts";
+	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	g_assert_nonnull(entry);
+	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_assert_cmpint(entry->mount_id, ==, 1);
+	g_assert_cmpint(entry->parent_id, ==, 2);
+	g_assert_cmpint(entry->dev_major, ==, 3);
+	g_assert_cmpint(entry->dev_minor, ==, 4);
+	g_assert_cmpstr(entry->root, ==, "root");
+	g_assert_cmpstr(entry->mount_dir, ==, "mount-dir");
+	g_assert_cmpstr(entry->mount_opts, ==, "mount-opts");
+	g_assert_cmpstr(entry->optional_fields, ==, "tag:1");
+	g_assert_cmpstr(entry->fs_type, ==, "fs-type");
+	g_assert_cmpstr(entry->mount_source, ==, "mount-source");
+	g_assert_cmpstr(entry->super_opts, ==, "super-opts");
+	g_assert_null(entry->next);
+}
+
+static void test_parse_mountinfo_entry__two_tags()
+{
+	const char *line =
+	    "1 2 3:4 root mount-dir mount-opts tag:1 tag:2 - fs-type mount-source super-opts";
+	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	g_assert_nonnull(entry);
+	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_assert_cmpint(entry->mount_id, ==, 1);
+	g_assert_cmpint(entry->parent_id, ==, 2);
+	g_assert_cmpint(entry->dev_major, ==, 3);
+	g_assert_cmpint(entry->dev_minor, ==, 4);
+	g_assert_cmpstr(entry->root, ==, "root");
+	g_assert_cmpstr(entry->mount_dir, ==, "mount-dir");
+	g_assert_cmpstr(entry->mount_opts, ==, "mount-opts");
+	g_assert_cmpstr(entry->optional_fields, ==, "tag:1 tag:2");
+	g_assert_cmpstr(entry->fs_type, ==, "fs-type");
+	g_assert_cmpstr(entry->mount_source, ==, "mount-source");
+	g_assert_cmpstr(entry->super_opts, ==, "super-opts");
+	g_assert_null(entry->next);
+}
+
 static void test_accessor_funcs()
 {
 	const char *line =
@@ -125,5 +188,11 @@ static void __attribute__ ((constructor)) init()
 			test_parse_mountinfo_entry__snapd_mnt);
 	g_test_add_func("/mountinfo/parse_mountinfo_entry/garbage",
 			test_parse_mountinfo_entry__garbage);
+	g_test_add_func("/mountinfo/parse_mountinfo_entry/no_tags",
+			test_parse_mountinfo_entry__no_tags);
+	g_test_add_func("/mountinfo/parse_mountinfo_entry/one_tags",
+			test_parse_mountinfo_entry__one_tag);
+	g_test_add_func("/mountinfo/parse_mountinfo_entry/two_tags",
+			test_parse_mountinfo_entry__two_tags);
 	g_test_add_func("/mountinfo/accessor_funcs", test_accessor_funcs);
 }

--- a/src/mountinfo-test.c
+++ b/src/mountinfo-test.c
@@ -86,6 +86,35 @@ static void test_parse_mountinfo_entry__snapd_mnt()
 	g_assert_null(entry->next);
 }
 
+static void test_parse_mountinfo_entry__garbage()
+{
+	const char *line = "256 104 0:3";
+	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	g_assert_null(entry);
+}
+
+static void test_accessor_funcs()
+{
+	const char *line =
+	    "256 104 0:3 mnt:[4026532509] /run/snapd/ns/hello-world.mnt rw - nsfs nsfs rw";
+	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	g_assert_nonnull(entry);
+	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_assert_cmpint(mountinfo_entry_mount_id(entry), ==, 256);
+	g_assert_cmpint(mountinfo_entry_parent_id(entry), ==, 104);
+	g_assert_cmpint(mountinfo_entry_dev_major(entry), ==, 0);
+	g_assert_cmpint(mountinfo_entry_dev_minor(entry), ==, 3);
+
+	g_assert_cmpstr(mountinfo_entry_root(entry), ==, "mnt:[4026532509]");
+	g_assert_cmpstr(mountinfo_entry_mount_dir(entry), ==,
+			"/run/snapd/ns/hello-world.mnt");
+	g_assert_cmpstr(mountinfo_entry_mount_opts(entry), ==, "rw");
+	g_assert_cmpstr(mountinfo_entry_optional_fields(entry), ==, "");
+	g_assert_cmpstr(mountinfo_entry_fs_type(entry), ==, "nsfs");
+	g_assert_cmpstr(mountinfo_entry_mount_source(entry), ==, "nsfs");
+	g_assert_cmpstr(mountinfo_entry_super_opts(entry), ==, "rw");
+}
+
 static void __attribute__ ((constructor)) init()
 {
 	g_test_add_func("/mountinfo/parse_mountinfo_entry/sysfs",
@@ -94,4 +123,7 @@ static void __attribute__ ((constructor)) init()
 			test_parse_mountinfo_entry__snapd_ns);
 	g_test_add_func("/mountinfo/parse_mountinfo_entry/snapd-mnt",
 			test_parse_mountinfo_entry__snapd_mnt);
+	g_test_add_func("/mountinfo/parse_mountinfo_entry/garbage",
+			test_parse_mountinfo_entry__garbage);
+	g_test_add_func("/mountinfo/accessor_funcs", test_accessor_funcs);
 }

--- a/src/mountinfo.c
+++ b/src/mountinfo.c
@@ -202,8 +202,8 @@ static struct mountinfo_entry *parse_mountinfo_entry(const char *line)
 	// it to the allocated entry structure.
 	//
 	// The parsing code below, specifically parse_next_string_field(), uses
-	// this extra memory to hold data parsed from the original line. In the end
-	// the result is similar to using strtok except that the source and
+	// this extra memory to hold data parsed from the original line. In the
+	// end, the result is similar to using strtok except that the source and
 	// destination buffers are separate.
 	struct mountinfo_entry *entry =
 	    calloc(1, sizeof *entry + strlen(line) + 1);

--- a/src/mountinfo.c
+++ b/src/mountinfo.c
@@ -192,19 +192,19 @@ struct mountinfo *parse_mountinfo(const char *fname)
 
 static struct mountinfo_entry *parse_mountinfo_entry(const char *line)
 {
-	// NOTE: the mouninfo structure is allocated along with enough extra storage
-	// to hold the whole line we are parsing. This is used as backing store for
-	// all of the text fields.
+	// NOTE: the mountinfo structure is allocated along with enough extra
+	// storage to hold the whole line we are parsing. This is used as backing
+	// store for all of the text fields.
 	//
 	// The idea is that since the line has a given length and we are only after
-	// set of substrings we can easily predict the amount of required data
+	// set of substrings we can easily predict the amount of required space
 	// (after all, it is just a set of non-overlapping substrings) and append
 	// it to the allocated entry structure.
 	//
-	// The parsing code below, specifically parse_next_string_field() uses this
-	// extra memory to hold data parsed from the original line. In the end the
-	// result is similar to using strtok except that the source and destination
-	// buffers are separate.
+	// The parsing code below, specifically parse_next_string_field(), uses
+	// this extra memory to hold data parsed from the original line. In the end
+	// the result is similar to using strtok except that the source and
+	// destination buffers are separate.
 	struct mountinfo_entry *entry =
 	    calloc(1, sizeof *entry + strlen(line) + 1);
 	if (entry == NULL) {

--- a/src/mountinfo.c
+++ b/src/mountinfo.c
@@ -225,6 +225,9 @@ static struct mountinfo_entry *parse_mountinfo_entry(const char *line)
 		if (strcmp(opt_field, "-") == 0) {
 			break;
 		}
+		if (*entry->optional_fields) {
+			strcat(entry->optional_fields, " ");
+		}
 		strcat(entry->optional_fields, opt_field);
 	}
 	if ((entry->fs_type = parse_next_string_field()) == NULL)

--- a/src/mountinfo.c
+++ b/src/mountinfo.c
@@ -38,7 +38,12 @@ struct mountinfo_entry {
 	char *super_opts;
 
 	struct mountinfo_entry *next;
-	char line_buf[0];	// Buffer holding all of the text data above;
+	// Buffer holding all of the text data above.
+	//
+	// The buffer must be the last element of the structure. It is allocated
+	// along with the structure itself and does not need to be freed
+	// separately.
+	char line_buf[0];
 };
 
 /**

--- a/src/mountinfo.c
+++ b/src/mountinfo.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mountinfo.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct mountinfo {
+	struct mountinfo_entry *first;
+};
+
+struct mountinfo_entry {
+	int mount_id;
+	int parent_id;
+	unsigned dev_major, dev_minor;
+	char *root;
+	char *mount_dir;
+	char *mount_opts;
+	char *optional_fields;
+	char *fs_type;
+	char *mount_source;
+	char *super_opts;
+
+	struct mountinfo_entry *next;
+	char line_buf[0];	// Buffer holding all of the text data above;
+};
+
+/**
+ * Parse a single mountinfo entry (line).
+ *
+ * The format, described by Linux kernel documentation, is as follows:
+ *
+ * 36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+ * (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
+ *
+ * (1) mount ID:  unique identifier of the mount (may be reused after umount)
+ * (2) parent ID:  ID of parent (or of self for the top of the mount tree)
+ * (3) major:minor:  value of st_dev for files on filesystem
+ * (4) root:  root of the mount within the filesystem
+ * (5) mount point:  mount point relative to the process's root
+ * (6) mount options:  per mount options
+ * (7) optional fields:  zero or more fields of the form "tag[:value]"
+ * (8) separator:  marks the end of the optional fields
+ * (9) filesystem type:  name of filesystem of the form "type[.subtype]"
+ * (10) mount source:  filesystem specific information or "none"
+ * (11) super options:  per super block options
+ **/
+static struct mountinfo_entry *parse_mountinfo_entry(const char *line)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Free a mountinfo structure and all its entries.
+ **/
+static void free_mountinfo(struct mountinfo *info)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Free a mountinfo entry.
+ **/
+static void free_mountinfo_entry(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+static void cleanup_fclose(FILE ** ptr);
+static void cleanup_free(char **ptr);
+
+struct mountinfo_entry *first_mountinfo_entry(struct mountinfo *info)
+{
+	return info->first;
+}
+
+struct mountinfo_entry *next_mountinfo_entry(struct mountinfo_entry
+					     *entry)
+{
+	return entry->next;
+}
+
+int mountinfo_entry_mount_id(struct mountinfo_entry *entry)
+{
+	return entry->mount_id;
+}
+
+int mountinfo_entry_parent_id(struct mountinfo_entry *entry)
+{
+	return entry->parent_id;
+}
+
+unsigned mountinfo_entry_dev_major(struct mountinfo_entry *entry)
+{
+	return entry->dev_major;
+}
+
+unsigned mountinfo_entry_dev_minor(struct mountinfo_entry *entry)
+{
+	return entry->dev_minor;
+}
+
+const char *mountinfo_entry_root(struct mountinfo_entry *entry)
+{
+	return entry->root;
+}
+
+const char *mountinfo_entry_mount_dir(struct mountinfo_entry *entry)
+{
+	return entry->mount_dir;
+}
+
+const char *mountinfo_entry_mount_opts(struct mountinfo_entry *entry)
+{
+	return entry->mount_opts;
+}
+
+const char *mountinfo_entry_optional_fields(struct mountinfo_entry *entry)
+{
+	return entry->optional_fields;
+}
+
+const char *mountinfo_entry_fs_type(struct mountinfo_entry *entry)
+{
+	return entry->fs_type;
+}
+
+const char *mountinfo_entry_mount_source(struct mountinfo_entry *entry)
+{
+	return entry->mount_source;
+}
+
+const char *mountinfo_entry_super_opts(struct mountinfo_entry *entry)
+{
+	return entry->super_opts;
+}
+
+struct mountinfo *parse_mountinfo(const char *fname)
+{
+	if (fname == NULL) {
+		fname = "/proc/self/mountinfo";
+	}
+	FILE *f __attribute__ ((cleanup(cleanup_fclose))) = fopen(fname, "rt");
+	if (f == NULL) {
+		return NULL;
+	}
+	struct mountinfo *info = calloc(1, sizeof *info);
+	if (info == NULL) {
+		return NULL;
+	}
+	char *line __attribute__ ((cleanup(cleanup_free))) = NULL;
+	size_t line_size = 0;
+	struct mountinfo_entry *entry, *last = NULL;
+	for (;;) {
+		errno = 0;
+		if (getline(&line, &line_size, f) == -1) {
+			if (errno != 0) {
+				free_mountinfo(info);
+				return NULL;
+			}
+			break;
+		};
+		entry = parse_mountinfo_entry(line);
+		if (entry == NULL) {
+			free_mountinfo(info);
+			return NULL;
+		}
+		if (last != NULL) {
+			last->next = entry;
+		} else {
+			info->first = entry;
+		}
+		last = entry;
+	}
+	return info;
+}
+
+static struct mountinfo_entry *parse_mountinfo_entry(const char *line)
+{
+	struct mountinfo_entry *entry =
+	    calloc(1, sizeof *entry + strlen(line) + 1);
+	if (entry == NULL) {
+		return NULL;
+	}
+	int nscanned;
+	int offset, total_offset = 0;
+	nscanned = sscanf(line, "%d %d %u:%u %n",
+			  &entry->mount_id, &entry->parent_id,
+			  &entry->dev_major, &entry->dev_minor, &offset);
+	if (nscanned != 4)
+		goto fail;
+	total_offset += offset;
+	int total_used = 0;
+	char *parse_next_string_field() {
+		char *field = &entry->line_buf[0] + total_used;
+		nscanned = sscanf(line + total_offset, "%s %n", field, &offset);
+		if (nscanned != 1)
+			return NULL;
+		total_offset += offset;
+		total_used += offset + 1;
+		return field;
+	}
+	if ((entry->root = parse_next_string_field()) == NULL)
+		goto fail;
+	if ((entry->mount_dir = parse_next_string_field()) == NULL)
+		goto fail;
+	if ((entry->mount_opts = parse_next_string_field()) == NULL)
+		goto fail;
+	entry->optional_fields = &entry->line_buf[0] + total_used++;
+	strcpy(entry->optional_fields, "");
+	for (;;) {
+		char *opt_field = parse_next_string_field();
+		if (opt_field == NULL)
+			goto fail;
+		if (strcmp(opt_field, "-") == 0) {
+			break;
+		}
+		strcat(entry->optional_fields, opt_field);
+	}
+	if ((entry->fs_type = parse_next_string_field()) == NULL)
+		goto fail;
+	if ((entry->mount_source = parse_next_string_field()) == NULL)
+		goto fail;
+	if ((entry->super_opts = parse_next_string_field()) == NULL)
+		goto fail;
+	return entry;
+ fail:
+	free(entry);
+	return NULL;
+}
+
+void cleanup_mountinfo(struct mountinfo **ptr)
+{
+	if (*ptr != NULL) {
+		free_mountinfo(*ptr);
+		*ptr = NULL;
+	}
+}
+
+static void free_mountinfo(struct mountinfo *info)
+{
+	struct mountinfo_entry *entry, *next;
+	for (entry = info->first; entry != NULL; entry = next) {
+		next = entry->next;
+		free_mountinfo_entry(entry);
+	}
+	free(info);
+}
+
+static void free_mountinfo_entry(struct mountinfo_entry *entry)
+{
+	free(entry);
+}
+
+static void cleanup_fclose(FILE ** ptr)
+{
+	fclose(*ptr);
+}
+
+static void cleanup_free(char **ptr)
+{
+	free(*ptr);
+}

--- a/src/mountinfo.c
+++ b/src/mountinfo.c
@@ -194,7 +194,7 @@ static struct mountinfo_entry *parse_mountinfo_entry(const char *line)
 {
 	// NOTE: the mountinfo structure is allocated along with enough extra
 	// storage to hold the whole line we are parsing. This is used as backing
-	// store for all of the text fields.
+	// store for all text fields.
 	//
 	// The idea is that since the line has a given length and we are only after
 	// set of substrings we can easily predict the amount of required space

--- a/src/mountinfo.c
+++ b/src/mountinfo.c
@@ -192,6 +192,19 @@ struct mountinfo *parse_mountinfo(const char *fname)
 
 static struct mountinfo_entry *parse_mountinfo_entry(const char *line)
 {
+	// NOTE: the mouninfo structure is allocated along with enough extra storage
+	// to hold the whole line we are parsing. This is used as backing store for
+	// all of the text fields.
+	//
+	// The idea is that since the line has a given length and we are only after
+	// set of substrings we can easily predict the amount of required data
+	// (after all, it is just a set of non-overlapping substrings) and append
+	// it to the allocated entry structure.
+	//
+	// The parsing code below, specifically parse_next_string_field() uses this
+	// extra memory to hold data parsed from the original line. In the end the
+	// result is similar to using strtok except that the source and destination
+	// buffers are separate.
 	struct mountinfo_entry *entry =
 	    calloc(1, sizeof *entry + strlen(line) + 1);
 	if (entry == NULL) {

--- a/src/mountinfo.h
+++ b/src/mountinfo.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SC_MOUNTINFO_H
+#define SC_MOUNTINFO_H
+
+/**
+ * Structure describing entire /proc/self/mountinfo file
+ **/
+struct mountinfo;
+
+/**
+ * Structure describing a single entry in /proc/self/mountinfo
+ **/
+struct mountinfo_entry;
+
+/**
+ * Parse a file in according to mountinfo syntax.
+ *
+ * The argument can be used to parse an arbitrary file.  NULL can be used to
+ * implicitly parse /proc/self/mountinfo, that is the mount information
+ * associated with the current process.
+ **/
+struct mountinfo *parse_mountinfo(const char *fname);
+
+/**
+ * Free a mountinfo structure.
+ *
+ * This function is designed to be used with __attribute__((cleanup)) so it
+ * takes a pointer to the freed object (which is also a pointer).
+ **/
+void cleanup_mountinfo(struct mountinfo **ptr) __attribute__ ((nonnull(1)));
+
+/**
+ * Get the first mountinfo entry.
+ *
+ * The returned value may be NULL if the parsed file contained no entries. The
+ * returned value is bound to the lifecycle of the whole mountinfo structure
+ * and should not be freed explicitly.
+ **/
+struct mountinfo_entry *first_mountinfo_entry(struct mountinfo *info)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the next mountinfo entry.
+ *
+ * The returned value is a pointer to the next mountinfo entry or NULL if this
+ * was the last entry. The returned value is bound to the lifecycle of the
+ * whole mountinfo structure and should not be freed explicitly.
+ **/
+struct mountinfo_entry *next_mountinfo_entry(struct mountinfo_entry
+					     *entry)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the moint identifier of a given mount entry.
+ **/
+int mountinfo_entry_mount_id(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the parent moint identifier of a given mount entry.
+ **/
+int mountinfo_entry_parent_id(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+unsigned mountinfo_entry_dev_major(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+unsigned mountinfo_entry_dev_minor(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the root directory of a given mount entry.
+ **/
+const char *mountinfo_entry_root(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the mount point of a given mount entry.
+ **/
+const char *mountinfo_entry_mount_dir(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the mount options of a given mount entry.
+ **/
+const char *mountinfo_entry_mount_opts(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get optional tagged data associated of a given mount entry.
+ *
+ * The return value is a string (possibly empty but never NULL) in the format
+ * tag[:value]. Known tags are:
+ *
+ * "shared:X":
+ * 		mount is shared in peer group X
+ * "master:X":
+ * 		mount is slave to peer group X
+ * "propagate_from:X"
+ * 		mount is slave and receives propagation from peer group X (*)
+ * "unbindable":
+ * 		mount is unbindable
+ *
+ * (*) X is the closest dominant peer group under the process's root.
+ * If X is the immediate master of the mount, or if there's no dominant peer
+ * group under the same root, then only the "master:X" field is present and not
+ * the "propagate_from:X" field.
+ **/
+const char *mountinfo_entry_optional_fields(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the file system type of a given mount entry.
+ **/
+const char *mountinfo_entry_fs_type(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the source of a given mount entry.
+ **/
+const char *mountinfo_entry_mount_source(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the super block options of a given mount entry.
+ **/
+const char *mountinfo_entry_super_opts(struct mountinfo_entry *entry)
+    __attribute__ ((nonnull(1)));
+
+#endif


### PR DESCRIPTION
This patch adds module capable of parsing /proc/self/mountinfo.

Snap-confine needs to parse this file to understand what is currently mounted in a way
that makes bind mounts visible (classic /proc/mounts is insufficient for this purpose).
For extra details about this topic see: https://lwn.net/Articles/265920/

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
