### PR TITLE
Remove test producing spurious results on trusty.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,7 +13,6 @@ all_tests = \
     test_noprofile \
     test_restrictions \
     test_restrictions_working \
-    test_restrictions_working_args \
     test_restrictions_working_args_prctl \
     test_restrictions_working_args_prio \
     test_restrictions_working_args_socket \


### PR DESCRIPTION
Seems to works fine on i386 and armhf, fails regularly on amd64.
