### PR TITLE
 Enable snap-confine namespace sharing

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -36,8 +36,8 @@ suites:
             # NOTE: before snapd discards namespaces on snap removal
             # we have to do it ourselves. All of the tests use one
             # snap so this is easier to work with.
-            /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt
+            /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt || :
     spread-tests/regression/:
         summary: Regression tests for past bug-fixes
         restore-each: |
-            /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt
+            /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt || :

--- a/spread.yaml
+++ b/spread.yaml
@@ -26,5 +26,12 @@ prepare: |
 suites:
     spread-tests/main/:
         summary: Full-system tests for snap-confine
+        restore:
+            # NOTE: before snapd discards namespaces on snap removal
+            # we have to do it ourselves. All of the tests use one
+            # snap so this is easier to work with.
+            /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt
     spread-tests/regression/:
         summary: Regression tests for past bug-fixes
+        restore:
+            /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt

--- a/spread.yaml
+++ b/spread.yaml
@@ -19,19 +19,24 @@ exclude:
     - autom4te.cache
 
 prepare: |
-    echo "Spread is running as $(id)"
     [ "$REUSE_PROJECT" != 1 ] || exit 0
+    if [ -f /etc/apt/apt.conf.d/95cloud-init-proxy ]; then
+        rm -f /etc/apt/apt.conf.d/95cloud-init-proxy
+    fi
+    if [ -n "${APT_PROXY:-}" ]; then
+        printf 'Acquire::http::Proxy "%s";\n' "$APT_PROXY" > /etc/apt/apt.conf.d/00aptproxy
+    fi
     ./spread-tests/spread-prepare.sh
 
 suites:
     spread-tests/main/:
         summary: Full-system tests for snap-confine
-        restore:
+        restore-each: |
             # NOTE: before snapd discards namespaces on snap removal
             # we have to do it ourselves. All of the tests use one
             # snap so this is easier to work with.
             /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt
     spread-tests/regression/:
         summary: Regression tests for past bug-fixes
-        restore:
+        restore-each: |
             /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt

--- a/src/mount-support.h
+++ b/src/mount-support.h
@@ -19,20 +19,6 @@
 #define SNAP_MOUNT_SUPPORT_H
 
 /**
- * Unshare the mount namespace.
- *
- * Ensure we run in our own slave mount namespace, this will create a new mount
- * namespace and make it a slave of "/"
- *
- * Note that this means that no mount actions inside our namespace are
- * propagated to the main "/". We need this both for the private /tmp we create
- * and for the bind mounts we do on a classic distribution system.
- *
- * This also means you can't run an automount daemon under this launcher.
- **/
-void sc_unshare_mount_ns();
-
-/**
  * Assuming a new mountspace, populate it accordingly.
  *
  * This function performs many internal tasks:

--- a/src/sc-main.c
+++ b/src/sc-main.c
@@ -36,6 +36,7 @@
 #include "udev-support.h"
 #include "cleanup-funcs.h"
 #include "user-support.h"
+#include "ns-support.h"
 #include "quirks.h"
 
 int sc_main(int argc, char **argv)
@@ -78,8 +79,21 @@ int sc_main(int argc, char **argv)
 #endif				// ifdef HAVE_SECCOMP
 
 	if (geteuid() == 0) {
-		sc_unshare_mount_ns();
-		sc_populate_mount_ns(security_tag);
+		const char *group_name = getenv("SNAP_NAME");
+		if (group_name == NULL) {
+			die("SNAP_NAME is not set");
+		}
+		sc_initialize_ns_groups();
+		struct sc_ns_group *group = NULL;
+		group = sc_open_ns_group(group_name);
+		sc_lock_ns_mutex(group);
+		sc_create_or_join_ns_group(group);
+		if (sc_should_populate_ns_group(group)) {
+			sc_populate_mount_ns(security_tag);
+			sc_preserve_populated_ns_group(group);
+		}
+		sc_unlock_ns_mutex(group);
+		sc_close_ns_group(group);
 		struct snappy_udev udev_s;
 		if (snappy_udev_init(security_tag, &udev_s) == 0)
 			setup_devices_cgroup(security_tag, &udev_s);

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -189,4 +189,69 @@
     mount options=(rw rbind nodev nosuid noexec) /var/lib/snapd/hostfs/var/lib/lxd/ -> /var/lib/lxd/,
     /var/lib/lxd/ w,
     /var/lib/snapd/hostfs/var/lib/lxd r,
+
+	# support for the mount namespace sharing
+	mount options=(rw rbind) /run/snapd/ns/ -> /run/snapd/ns/,
+	mount options=(private) -> /run/snapd/ns/,
+	/ rw,
+	/run/ rw,
+	/run/snapd/ rw,
+	/run/snapd/ns/ rw,
+	/run/snapd/ns/*.lock rwk,
+	/run/snapd/ns/*.mnt rw,
+	ptrace,
+	owner @{PROC}/*/mountinfo r,
+	capability sys_chroot,
+	capability sys_admin,
+	signal (send) set=("int") peer=@LIBEXECDIR@//mount-namespace-capture-helper,
+
+	^mount-namespace-capture-helper (attach_disconnected) {
+		# We run privileged, so be fanatical about what we include and don't use
+		# any abstractions
+		/etc/ld.so.cache r,
+		/lib/@{multiarch}/ld-*.so mr,
+		# libc, you are funny
+		/lib/@{multiarch}/libc{,-[0-9]*}.so* mr,
+		/lib/@{multiarch}/libpthread{,-[0-9]*}.so* mr,
+		/lib/@{multiarch}/librt{,-[0-9]*}.so* mr,
+		/lib/@{multiarch}/libgcc_s.so* mr,
+		# normal libs in order
+		/lib/@{multiarch}/libapparmor.so* mr,
+		/lib/@{multiarch}/libcgmanager.so* mr,
+		/lib/@{multiarch}/libnih.so* mr,
+		/lib/@{multiarch}/libnih-dbus.so* mr,
+		/lib/@{multiarch}/libdbus-1.so* mr,
+		/lib/@{multiarch}/libudev.so* mr,
+		/usr/lib/@{multiarch}/libseccomp.so* mr,
+		/lib/@{multiarch}/libseccomp.so* mr,
+
+		@LIBEXECDIR@/snap-confine r,
+
+		/dev/null rw,
+		/dev/full rw,
+		/dev/zero rw,
+		/dev/random r,
+		/dev/urandom r,
+
+		capability sys_ptrace,
+		capability sys_admin,
+		/ r,
+		owner @{PROC}/ r,
+		owner @{PROC}/*/ r,
+		owner @{PROC}/*/ns/ r,
+		owner @{PROC}/*/ns/mnt r,
+		/run/ r,
+		/run/snapd/ r,
+		/run/snapd/ns/ r,
+		/run/snapd/ns/*.mnt rw,
+		# mount options=(rw bind) /proc/*/ns/mnt/ -> /run/snapd/ns/*.mnt/,
+		mount options=(rw bind) -> /run/snapd/ns/*.mnt,
+		signal (receive) peer=unconfined,
+		signal (receive) set=("int") peer=@LIBEXECDIR@//mount-namespace-capture-helper,
+		ptrace (tracedby) peer=@LIBEXECDIR@/snap-confine,
+		ptrace,
+	}
+
+	# Allow snap-confine to be killed
+    signal (receive) peer=unconfined,
 }

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -203,7 +203,7 @@
 	owner @{PROC}/*/mountinfo r,
 	capability sys_chroot,
 	capability sys_admin,
-	signal (send) set=("int") peer=@LIBEXECDIR@//mount-namespace-capture-helper,
+	signal (send) set=("int") peer=@LIBEXECDIR@snap-confine//mount-namespace-capture-helper,
 
 	^mount-namespace-capture-helper (attach_disconnected) {
 		# We run privileged, so be fanatical about what we include and don't use
@@ -247,7 +247,7 @@
 		# mount options=(rw bind) /proc/*/ns/mnt/ -> /run/snapd/ns/*.mnt/,
 		mount options=(rw bind) -> /run/snapd/ns/*.mnt,
 		signal (receive) peer=unconfined,
-		signal (receive) set=("int") peer=@LIBEXECDIR@//mount-namespace-capture-helper,
+		signal (receive) set=("int") peer=@LIBEXECDIR@snap-confine//mount-namespace-capture-helper,
 		ptrace (tracedby) peer=@LIBEXECDIR@/snap-confine,
 		ptrace,
 	}

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -248,6 +248,7 @@
 		mount options=(rw bind) -> /run/snapd/ns/*.mnt,
 		signal (receive) peer=unconfined,
 		signal (receive) set=("int") peer=@LIBEXECDIR@snap-confine//mount-namespace-capture-helper,
+		signal (receive) set=("int") peer=@LIBEXECDIR@snap-confine,
 		ptrace (tracedby) peer=@LIBEXECDIR@/snap-confine,
 		ptrace,
 	}


### PR DESCRIPTION
This branch changes mount-support.[ch] a little so that there's no
explicit unshare API anymore (this is handled by ns-support.h) and so
that mount-suppor.h is really just about populating the namespace that
is already provided.

In addition, sc-main.c now uses SNAP_NAME to join or create a namespace
group and if populates it if necessary. The apparmor profile is updated
to let snap-confine perform the additional tasks.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
