### PR TITLE
Add snap-discard-ns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 src/snap-confine
+src/snap-discard-ns
 src/snap-confine-unit-tests
 src/snap-confine.apparmor
 *~

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,9 +1,9 @@
-dist_man_MANS = snap-confine.5 ubuntu-core-launcher.1
+dist_man_MANS = snap-confine.5 snap-discard-ns.5 ubuntu-core-launcher.1
 
-CLEANFILES = snap-confine.5 ubuntu-core-launcher.1
-EXTRA_DIST = snap-confine.rst ubuntu-core-launcher.rst
+CLEANFILES = snap-confine.5 snap-discard-ns.5 ubuntu-core-launcher.1
+EXTRA_DIST = snap-confine.rst snap-discard-ns.rst ubuntu-core-launcher.rst
 
-snap-confine.5: snap-confine.rst
+%.5: %.rst
 	rst2man $^ > $@
 
 ubuntu-core-launcher.1: ubuntu-core-launcher.rst

--- a/docs/snap-discard-ns.rst
+++ b/docs/snap-discard-ns.rst
@@ -1,0 +1,53 @@
+================
+ snap-discard-ns
+================
+
+------------------------------------------------------------------------
+internal tool for discarding preserved namespaces of snappy applications
+------------------------------------------------------------------------
+
+:Author: zygmunt.krynicki@canonical.com
+:Date:   2016-09-12
+:Copyright: Canonical Ltd.
+:Version: 1.0.41
+:Manual section: 5
+:Manual group: snappy
+
+SYNOPSIS
+========
+
+	snap-discard-ns SNAP_NAME
+
+DESCRIPTION
+===========
+
+The `snap-discard-ns` is a program used internally by `snapd` to discard a preserved
+mount namespace of a particular snap.
+
+OPTIONS
+=======
+
+The `snap-confine` program does not support any options.
+
+ENVIRONMENT
+===========
+
+`snap-discard-ns` responds to the following environment variables
+
+`SNAP_CONFINE_DEBUG`:
+	When defined the program will print additional diagnostic information about
+	the actions being performed. All the output goes to stderr.
+
+FILES
+=====
+
+`snap-discard-ns` uses the following files:
+
+`/run/snapd/ns/$SNAP_NAME.mnt`:
+
+    The preserved mount namespace that is unmounted by `snap-discard-ns`.
+
+BUGS
+====
+
+Please report all bugs with https://bugs.launchpad.net/snap-confine/+filebug

--- a/docs/snap-discard-ns.rst
+++ b/docs/snap-discard-ns.rst
@@ -27,7 +27,7 @@ mount namespace of a particular snap.
 OPTIONS
 =======
 
-The `snap-confine` program does not support any options.
+The `snap-discard-ns` program does not support any options.
 
 ENVIRONMENT
 ===========

--- a/spread-tests/main/discard-ns/task.yaml
+++ b/spread-tests/main/discard-ns/task.yaml
@@ -1,0 +1,16 @@
+summary: Check that snap-discard-ns works
+# This is blacklisted on debian because debian doesn't use apparmor yet
+systems: [-debian-8]
+details: |
+    The internal snap-discard-ns program is supposed to simply unmount
+    whatever is mounted at /run/snapd/ns/$SNAP_NAME.mnt
+prepare: |
+    mkdir -d /run/snapd/ns/
+    mount --bind /run/snapd/ns /run/snapd/ns
+    mount --make-private /run/snapd/ns
+    unshare --mount=/run/snapd/ns/foo.mnt true
+execute: |
+    /usr/lib/snapd/snap-discard-ns foo
+    ! grep foo.mnt /proc/self/mountinfo
+restore: |
+    umount /run/snapd/ns

--- a/spread-tests/main/discard-ns/task.yaml
+++ b/spread-tests/main/discard-ns/task.yaml
@@ -5,7 +5,7 @@ details: |
     The internal snap-discard-ns program is supposed to simply unmount
     whatever is mounted at /run/snapd/ns/$SNAP_NAME.mnt
 prepare: |
-    mkdir -d /run/snapd/ns/
+    mkdir -p /run/snapd/ns/
     mount --bind /run/snapd/ns /run/snapd/ns
     mount --make-private /run/snapd/ns
     unshare --mount=/run/snapd/ns/foo.mnt true

--- a/spread-tests/main/discard-ns/task.yaml
+++ b/spread-tests/main/discard-ns/task.yaml
@@ -18,5 +18,4 @@ restore: |
     umount /run/snapd/ns
     rm /run/snapd/ns/foo.mnt
     rm /run/snapd/ns/foo.lock
-    rm /run/snapd/ns/.lock
     rmdir /run/snapd/ns

--- a/spread-tests/main/discard-ns/task.yaml
+++ b/spread-tests/main/discard-ns/task.yaml
@@ -17,4 +17,6 @@ restore: |
     umount /run/snapd/ns/foo.mnt || :
     umount /run/snapd/ns
     rm /run/snapd/ns/foo.mnt
+    rm /run/snapd/ns/foo.lock
+    rm /run/snapd/ns/.lock
     rmdir /run/snapd/ns

--- a/spread-tests/main/discard-ns/task.yaml
+++ b/spread-tests/main/discard-ns/task.yaml
@@ -8,9 +8,13 @@ prepare: |
     mkdir -p /run/snapd/ns/
     mount --bind /run/snapd/ns /run/snapd/ns
     mount --make-private /run/snapd/ns
+    touch /run/snapd/ns/foo.mnt
     unshare --mount=/run/snapd/ns/foo.mnt true
 execute: |
     /usr/lib/snapd/snap-discard-ns foo
     ! grep foo.mnt /proc/self/mountinfo
 restore: |
+    umount /run/snapd/ns/foo.mnt || :
     umount /run/snapd/ns
+    rm /run/snapd/ns/foo.mnt
+    rmdir /run/snapd/ns

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,31 @@
-libexec_PROGRAMS = snap-confine
+libexec_PROGRAMS = snap-confine snap-discard-ns
 if WITH_UNIT_TESTS
 noinst_PROGRAMS = snap-confine-unit-tests
 endif
+
+snap_discard_ns_SOURCES = \
+	ns-support.c \
+	ns-support.h \
+	user-support.c \
+	user-support.h \
+	utils.c \
+	utils.h \
+	cleanup-funcs.c \
+	cleanup-funcs.h \
+	mountinfo.c \
+	mountinfo.h \
+	snap-discard-ns.c
+snap_discard_ns_CFLAGS = -Wall -Werror $(AM_CFLAGS)
+snap_discard_ns_LDFLAGS = $(AM_LDFLAGS)
+snap_discard_ns_LDADD =
+snap_discard_ns_CFLAGS += $(SECCOMP_CFLAGS)
+snap_discard_ns_LDADD += $(SECCOMP_LIBS)
+
+if APPARMOR
+snap_discard_ns_CFLAGS += $(APPARMOR_CFLAGS)
+snap_discard_ns_LDADD += $(APPARMOR_LIBS)
+endif
+
 snap_confine_SOURCES = \
 	main.c \
 	sc-main.c \

--- a/src/snap-discard-ns.c
+++ b/src/snap-discard-ns.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "utils.h"
+#include "ns-support.h"
+
+int main(int argc, char **argv)
+{
+	if (argc != 2)
+		die("Usage: %s snap-name", argv[0]);
+	const char *snap_name = argv[1];
+	struct sc_ns_group *group = sc_open_ns_group(snap_name);
+	sc_lock_ns_mutex(group);
+	sc_discard_preserved_ns_group(group);
+	sc_unlock_ns_mutex(group);
+	sc_close_ns_group(group);
+	return 0;
+}


### PR DESCRIPTION
This branch adds the `snap-discard-ns` program that does as the name suggests. It is a part of the namespace sharing feature. This program will be used by snap-confine spread tests before the appropriate branch lands in snapd (https://github.com/snapcore/snapd/pull/1847)
