### PR TITLE
Add support for running spread tests in qemu

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -9,4 +9,4 @@ trap 'rm -rf "$TMP_SPREAD"' EXIT
 export PATH=$TMP_SPREAD:$PATH
 ( cd "$TMP_SPREAD" && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
-spread -v
+spread -v linode:

--- a/spread-tests/distros/debian.common
+++ b/spread-tests/distros/debian.common
@@ -1,4 +1,8 @@
-distro_archive=http://ftp.debian.org/debian
+if [ -n "${APT_PROXY:-}" ]; then
+    distro_archive=${APT_PROXY}/ftp.debian.org/debian
+else
+    distro_archive=http://ftp.debian.org/debian
+fi
 # NOTE: Debian packaging needs to be updated. I sent a mail to the
 # debian maintainer with instructions on what needs to happen and
 # how it fits into the CI system.

--- a/spread-tests/distros/ubuntu.common
+++ b/spread-tests/distros/ubuntu.common
@@ -1,3 +1,7 @@
-distro_archive=http://archive.ubuntu.com/ubuntu
+if [ -n "$APT_PROXY" ]; then
+    distro_archive=${APT_PROXY}/archive.ubuntu.com/ubuntu
+else
+    distro_archive=http://archive.ubuntu.com/ubuntu
+fi
 distro_packaging_git=https://git.launchpad.net/snap-confine
 sbuild_createchroot_extra="--components=main,universe"

--- a/spread-tests/distros/ubuntu.common
+++ b/spread-tests/distros/ubuntu.common
@@ -1,4 +1,4 @@
-if [ -n "$APT_PROXY" ]; then
+if [ -n "${APT_PROXY:-}" ]; then
     distro_archive=${APT_PROXY}/archive.ubuntu.com/ubuntu
 else
     distro_archive=http://archive.ubuntu.com/ubuntu

--- a/spread-tests/spread-prepare.sh
+++ b/spread-tests/spread-prepare.sh
@@ -112,6 +112,10 @@ esac
 # Install all the build dependencies
 case "$release_ID" in
     ubuntu|debian)
+        # treat APT_PROXY as a location of apt-cacher-ng to use
+        if [ -n "${APT_PROXY:-}" ]; then
+            printf 'Acquire::http::Proxy "%s";\n' "$APT_PROXY" > /etc/apt/apt.conf.d/00proxy
+        fi
         # trusty support is under development right now
         # we special-case the release until we have officially landed
         if [ "$release_ID" = "ubuntu" ] && [ "$release_VERSION_ID" = "14.04" ]; then

--- a/spread-tests/spread-prepare.sh
+++ b/spread-tests/spread-prepare.sh
@@ -116,6 +116,8 @@ case "$release_ID" in
         if [ -n "${APT_PROXY:-}" ]; then
             printf 'Acquire::http::Proxy "%s";\n' "$APT_PROXY" > /etc/apt/apt.conf.d/00proxy
         fi
+        # cope with unexpected /etc/apt/apt.conf.d/95cloud-init-proxy that may be in the image
+        rm -f /etc/apt/apt.conf.d/95cloud-init-proxy || :
         # trusty support is under development right now
         # we special-case the release until we have officially landed
         if [ "$release_ID" = "ubuntu" ] && [ "$release_VERSION_ID" = "14.04" ]; then

--- a/spread.yaml
+++ b/spread.yaml
@@ -27,7 +27,7 @@ exclude:
 
 prepare: |
     echo "Spread is running as $(id)"
-    [ "$REUSE_PROJECT" != 1 ] || exit 0
+    [ "${REUSE_PROJECT:-}" != 1 ] || exit 0
     ./spread-tests/spread-prepare.sh
 
 suites:

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,8 +1,8 @@
 project: snap-confine
 
 environment:
-    REUSE_PROJECT: $(echo $REUSE_PROJECT)
-    PATH: /snap/bin:$PATH
+    REUSE_PROJECT: "$(HOST:echo $REUSE_PROJECT)"
+    PATH: "/snap/bin:$PATH"
 
 backends:
     linode:

--- a/spread.yaml
+++ b/spread.yaml
@@ -10,6 +10,13 @@ backends:
         systems:
             - ubuntu-16.04-64-grub
             # - ubuntu-16.04-32-grub
+    qemu:
+        systems:
+            - ubuntu-16.04:
+                username: ubuntu
+                password: ubuntu
+                environment:
+                    APT_PROXY: "$(HOST: echo $APT_PROXY)"
 
 path: /remote/path/
 


### PR DESCRIPTION
This branch adds support for spread tests that can be ran locally with qemu.

As an optimization, the environment variable APT_PROXY can be pointed to a local apt-cacher-ng instance to optimize package downloads.
