### PR TITLE
Discard snapd-hacker-toolbelt namespaces on restore

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -33,5 +33,12 @@ prepare: |
 suites:
     spread-tests/main/:
         summary: Full-system tests for snap-confine
+        restore-each: |
+            # NOTE: before snapd discards namespaces on snap removal
+            # we have to do it ourselves. All of the tests use one
+            # snap so this is easier to work with.
+            /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt || :
     spread-tests/regression/:
         summary: Regression tests for past bug-fixes
+        restore-each: |
+            /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt || :


### PR DESCRIPTION
Because tests assume pristine test environment and preserved mount
namespaces are not yet discarded by snapd on the removal of a given snap
(branch pending but not merged) we just do it by hand.

Since not all of the tests currently use the snapd-hacker-toolbelt snap
the cleanup code is allowed to fail by ignoring any errors.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
