### PR TITLE
Allow snap-confine to read the void directory

### DIFF
--- a/spread-tests/regression/lp-1595444/task.yaml
+++ b/spread-tests/regression/lp-1595444/task.yaml
@@ -21,5 +21,5 @@ restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt
     rmdir /foo
-    # FIXME: remove this once apparmor profile allows accessing the-void to snap-confine
+    # NOTE: snapd-hacker-toolbelt is blocked by apparmor from reading /var/lib/snapd/void
     dmesg -c

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -173,6 +173,9 @@
     @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
     @{HOMEDIRS}/.ecryptfs/*/.Private/** mrixwlk,
 
+    # Allow snap-confine to move to the void
+    /var/lib/snapd/void/ r,
+
     # Support for the quirk system
     /var/ r,
     /var/lib/ r,


### PR DESCRIPTION
The apparmor profile for snap-confine needs to allow reading of the
/var/lib/snapd/void directory so that we can safely chdir there.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
