### PR TITLE
Add sanity timeouts

### DIFF
--- a/src/ns-support-test.c
+++ b/src/ns-support-test.c
@@ -323,9 +323,26 @@ static void test_nsfs_fs_id()
 	g_assert_cmpint(buf.f_type, ==, NSFS_MAGIC);
 }
 
+static void test_sc_enable_sanity_timeout()
+{
+	if (g_test_subprocess()) {
+		sc_enable_sanity_timeout();
+		debug("waiting...");
+		usleep(4 * G_USEC_PER_SEC);
+		debug("woke up");
+		sc_disable_sanity_timeout();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 5 * G_USEC_PER_SEC,
+			       G_TEST_SUBPROCESS_INHERIT_STDERR);
+	g_test_trap_assert_failed();
+}
+
 static void __attribute__ ((constructor)) init()
 {
 	g_test_add_func("/internal/rm_rf_tmp", test_rm_rf_tmp);
+	g_test_add_func("/ns/sc_enable_sanity_timeout",
+			test_sc_enable_sanity_timeout);
 	g_test_add_func("/ns/sc_alloc_ns_group", test_sc_alloc_ns_group);
 	g_test_add_func("/ns/sc_init_ns_group", test_sc_open_ns_group);
 	g_test_add_func("/ns/sc_lock_unlock_ns_mutex",

--- a/src/ns-support.c
+++ b/src/ns-support.c
@@ -67,7 +67,8 @@ static void sc_SIGALRM_handler(int signum)
  * are interrupted and a flag is set.
  *
  * The call should be paired with sc_disable_sanity_check_timeout() that
- * disabled the alarm and acts on the flag, aborting the process.
+ * disables the alarm and acts on the flag, aborting the process if the timeout
+ * gets exceeded.
  **/
 static void __attribute__ ((used)) sc_enable_sanity_timeout()
 {

--- a/src/ns-support.c
+++ b/src/ns-support.c
@@ -91,13 +91,13 @@ static void __attribute__ ((used)) sc_enable_sanity_timeout()
  **/
 static void __attribute__ ((used)) sc_disable_sanity_timeout()
 {
+	if (sanity_timeout_expired) {
+		die("sanity timeout expired");
+	}
 	alarm(0);
 	struct sigaction act = { };
 	if (sigaction(SIGALRM, &act, NULL) < 0) {
 		die("cannot uninstall signal handler for SIGALRM");
-	}
-	if (sanity_timeout_expired) {
-		die("sanity timeout expired");
 	}
 	debug("sanity timeout reset and disabled");
 }

--- a/src/ns-support.c
+++ b/src/ns-support.c
@@ -79,6 +79,7 @@ static void __attribute__ ((used)) sc_enable_sanity_timeout()
 	// NOTE: we are using sigaction so that we can explicitly control signal
 	// flags and *not* pass the SA_RESTART flag. The intent is so that any
 	// system call we may be sleeping on to get interrupted.
+	act.sa_flags = 0;
 	if (sigaction(SIGALRM, &act, NULL) < 0) {
 		die("cannot install signal handler for SIGALRM");
 	}

--- a/src/ns-support.c
+++ b/src/ns-support.c
@@ -74,8 +74,9 @@ static void __attribute__ ((used)) sc_enable_sanity_timeout()
 {
 	sanity_timeout_expired = 0;
 	struct sigaction act = {.sa_handler = sc_SIGALRM_handler };
-	if (sigemptyset(&act.sa_mask) < 0)
+	if (sigemptyset(&act.sa_mask) < 0) {
 		die("cannot initialize POSIX signal set");
+	}
 	// NOTE: we are using sigaction so that we can explicitly control signal
 	// flags and *not* pass the SA_RESTART flag. The intent is so that any
 	// system call we may be sleeping on to get interrupted.
@@ -100,8 +101,9 @@ static void __attribute__ ((used)) sc_disable_sanity_timeout()
 	}
 	alarm(0);
 	struct sigaction act = {.sa_handler = SIG_DFL };
-	if (sigemptyset(&act.sa_mask) < 0)
+	if (sigemptyset(&act.sa_mask) < 0) {
 		die("cannot initialize POSIX signal set");
+	}
 	if (sigaction(SIGALRM, &act, NULL) < 0) {
 		die("cannot uninstall signal handler for SIGALRM");
 	}

--- a/src/ns-support.c
+++ b/src/ns-support.c
@@ -80,7 +80,7 @@ static void __attribute__ ((used)) sc_enable_sanity_timeout()
 		die("cannot install signal handler for SIGALRM");
 	}
 	alarm(3);
-	debug("initiated three second failure timer");
+	debug("sanity timeout initialized and set for three seconds");
 }
 
 /**
@@ -92,7 +92,6 @@ static void __attribute__ ((used)) sc_enable_sanity_timeout()
 static void __attribute__ ((used)) sc_disable_sanity_timeout()
 {
 	alarm(0);
-	debug("reset and disabled the failure timer");
 	struct sigaction act = { };
 	if (sigaction(SIGALRM, &act, NULL) < 0) {
 		die("cannot uninstall signal handler for SIGALRM");
@@ -100,6 +99,7 @@ static void __attribute__ ((used)) sc_disable_sanity_timeout()
 	if (sanity_timeout_expired) {
 		die("sanity timeout expired");
 	}
+	debug("sanity timeout reset and disabled");
 }
 
 /*!

--- a/src/ns-support.c
+++ b/src/ns-support.c
@@ -99,7 +99,7 @@ static void __attribute__ ((used)) sc_disable_sanity_timeout()
 		die("sanity timeout expired");
 	}
 	alarm(0);
-	struct sigaction act = { };
+	struct sigaction act = {.sa_handler = SIG_DFL };
 	if (sigemptyset(&act.sa_mask) < 0)
 		die("cannot initialize POSIX signal set");
 	if (sigaction(SIGALRM, &act, NULL) < 0) {

--- a/src/ns-support.c
+++ b/src/ns-support.c
@@ -74,6 +74,8 @@ static void __attribute__ ((used)) sc_enable_sanity_timeout()
 {
 	sanity_timeout_expired = 0;
 	struct sigaction act = {.sa_handler = sc_SIGALRM_handler };
+	if (sigemptyset(&act.sa_mask) < 0)
+		die("cannot initialize POSIX signal set");
 	// NOTE: we are using sigaction so that we can explicitly control signal
 	// flags and *not* pass the SA_RESTART flag. The intent is so that any
 	// system call we may be sleeping on to get interrupted.
@@ -97,6 +99,8 @@ static void __attribute__ ((used)) sc_disable_sanity_timeout()
 	}
 	alarm(0);
 	struct sigaction act = { };
+	if (sigemptyset(&act.sa_mask) < 0)
+		die("cannot initialize POSIX signal set");
 	if (sigaction(SIGALRM, &act, NULL) < 0) {
 		die("cannot uninstall signal handler for SIGALRM");
 	}

--- a/src/ns-support.c
+++ b/src/ns-support.c
@@ -69,7 +69,7 @@ static void sc_SIGALRM_handler(int signum)
  * The call should be paired with sc_disable_sanity_check_timeout() that
  * disabled the alarm and acts on the flag, aborting the process.
  **/
-static void sc_enable_sanity_timeout()
+static void __attribute__ ((used)) sc_enable_sanity_timeout()
 {
 	sanity_timeout_expired = 0;
 	struct sigaction act = {.sa_handler = sc_SIGALRM_handler };
@@ -89,7 +89,7 @@ static void sc_enable_sanity_timeout()
  * This call has to be paired with sc_enable_sanity_timeout(), see the function
  * description for more details.
  **/
-static void sc_disable_sanity_timeout()
+static void __attribute__ ((used)) sc_disable_sanity_timeout()
 {
 	alarm(0);
 	debug("reset and disabled the failure timer");


### PR DESCRIPTION
This patch adds library functions to ensure that ensures a system call
such as flock() doesn't block for more than a given "sanity timeout"
value. This is meant to guard against bugs in the code that might
manifest as hanging process, keeping a flock-based lock alive, that will
never wake up.

The timer is implemented using SIGARLM and alarm(). The intent is to
simply wake up the system call and detect a flag being set by the signal
handler. This relies on using a signal handler that is not restarting
system calls.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
