### PR TITLE
Don't assume /run/snapd/ns can be removed

### DIFF
--- a/spread-tests/main/discard-ns/task.yaml
+++ b/spread-tests/main/discard-ns/task.yaml
@@ -18,3 +18,6 @@ restore: |
     umount /run/snapd/ns
     rm /run/snapd/ns/foo.mnt
     rm /run/snapd/ns/foo.lock
+    # The removal is optional as the directory may contain other files
+    # that we don't want to touch here.
+    rmdir /run/snapd/ns || true

--- a/spread-tests/main/discard-ns/task.yaml
+++ b/spread-tests/main/discard-ns/task.yaml
@@ -18,4 +18,3 @@ restore: |
     umount /run/snapd/ns
     rm /run/snapd/ns/foo.mnt
     rm /run/snapd/ns/foo.lock
-    rmdir /run/snapd/ns


### PR DESCRIPTION
This patch fixes a test case that is overzealous in the assumption that
/run/snapd/ns can be removed. That directory can contain additional
mount and lock files from any snaps present on the system that have run
earlier.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
