### PR TITLE
Add regression test for /usr/src

### DIFF
--- a/spread-tests/regression/lp-1597842/task.yaml
+++ b/spread-tests/regression/lp-1597842/task.yaml
@@ -1,0 +1,18 @@
+summary: Regression test for https://bugs.launchpad.net/snap-confine/+bug/1597842
+details: |
+    The snap execution environment is expected to contain the /usr/src
+    directory from the classic distribution. Certain snaps may use that to
+    access kernel sources.
+prepare: |
+    # NOTE: devmode is required because there's no interface for reading /usr/src/.canary
+    snap install --devmode snapd-hacker-toolbelt
+    mkdir -p /usr/src
+    echo canary > /usr/src/.canary
+execute: |
+    export PATH=/snap/bin:$PATH
+    echo "The canary file in /usr/src can be read"
+    [ "$(snapd-hacker-toolbelt.busybox cat /usr/src/.canary)" = "canary" ]
+restore: |
+    snap remove snapd-hacker-toolbelt
+    rm -f /usr/src/.canary
+    rmdir /usr/src || true


### PR DESCRIPTION
I'm working on the SRU process and some bugs fixed didn't have a corresponding regression test. Here's one more :)

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
