### PR TITLE
Make snap-discard-ns fail gracefully

### DIFF
--- a/spread-tests/main/discard-inexisting-ns/task.yaml
+++ b/spread-tests/main/discard-inexisting-ns/task.yaml
@@ -3,7 +3,8 @@ details: |
     The internal snap-discard-ns program is supposed to simply unmount
     whatever is mounted at /run/snapd/ns/$SNAP_NAME.mnt. In case of
     some specific failures though, we don't expect it to fail.
-prepare:
+prepare: |
+    umount /run/snapd/ns || true
     rm -rf /run/snapd/ns
 execute: |
     echo "We can try to discard a namespace before *any* snap runs"

--- a/spread-tests/main/discard-inexisting-ns/task.yaml
+++ b/spread-tests/main/discard-inexisting-ns/task.yaml
@@ -1,0 +1,20 @@
+summary: Check that snap-discard-ns gracefully handles errors
+details: |
+    The internal snap-discard-ns program is supposed to simply unmount
+    whatever is mounted at /run/snapd/ns/$SNAP_NAME.mnt. In case of
+    some specific failures though, we don't expect it to fail.
+prepare:
+    rm -rf /run/snapd/ns
+execute: |
+    echo "We can try to discard a namespace before *any* snap runs"
+    /usr/lib/snapd/snap-discard-ns foo
+    echo "We can try to discard a namespace before the .mnt file exits"
+    mkdir -p /run/snapd/ns/
+    /usr/lib/snapd/snap-discard-ns foo
+    echo "We can try to discard a namespace before the .mnt file is mounted"
+    touch /run/snapd/ns/foo.mnt
+    /usr/lib/snapd/snap-discard-ns foo
+restore: |
+    rm /run/snapd/ns/foo.mnt
+    rm /run/snapd/ns/foo.lock
+    rmdir /run/snapd/ns

--- a/spread.yaml
+++ b/spread.yaml
@@ -40,6 +40,7 @@ suites:
             # NOTE: before snapd discards namespaces on snap removal
             # we have to do it ourselves. All of the tests use one
             # snap so this is easier to work with.
+            /usr/lib/snapd/snap-discard-ns hello-world || true
             /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt || true
             test "$(dmesg | grep DENIED | wc -l)" -eq 0
     spread-tests/regression/:
@@ -49,5 +50,6 @@ suites:
             test "$(pgrep -c ubuntu-core-launcher)" -eq 0
             test "$(pgrep -c snap-confine)" -eq 0
             # See the note above about discarding namespaces
+            /usr/lib/snapd/snap-discard-ns hello-world || true
             /usr/lib/snapd/snap-discard-ns snapd-hacker-toolbelt || true
             test "$(dmesg | grep DENIED | wc -l)" -eq 0

--- a/src/ns-support-test.c
+++ b/src/ns-support-test.c
@@ -155,7 +155,7 @@ static struct sc_ns_group *sc_test_open_ns_group(const char *group_name)
 	if (group_name == NULL) {
 		group_name = "test-group";
 	}
-	group = sc_open_ns_group(group_name);
+	group = sc_open_ns_group(group_name, 0);
 	g_test_queue_destroy((GDestroyNotify) sc_close_ns_group, group);
 	// Check if the returned group data looks okay
 	g_assert_nonnull(group);

--- a/src/ns-support-test.c
+++ b/src/ns-support-test.c
@@ -185,6 +185,15 @@ static void test_sc_open_ns_group()
 		      (lock_file, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR));
 }
 
+static void test_sc_open_ns_group_graceful()
+{
+	sc_set_ns_dir("/nonexistent");
+	g_test_queue_destroy((GDestroyNotify) sc_set_ns_dir, SC_NS_DIR);
+	struct sc_ns_group *group =
+	    sc_open_ns_group("foo", SC_NS_FAIL_GRACEFULLY);
+	g_assert_null(group);
+}
+
 static void test_sc_lock_ns_mutex_precondition()
 {
 	sc_test_use_fake_ns_dir();
@@ -361,7 +370,9 @@ static void __attribute__ ((constructor)) init()
 	g_test_add_func("/ns/sc_enable_sanity_timeout",
 			test_sc_enable_sanity_timeout);
 	g_test_add_func("/ns/sc_alloc_ns_group", test_sc_alloc_ns_group);
-	g_test_add_func("/ns/sc_init_ns_group", test_sc_open_ns_group);
+	g_test_add_func("/ns/sc_open_ns_group", test_sc_open_ns_group);
+	g_test_add_func("/ns/sc_open_ns_group/graceful",
+			test_sc_open_ns_group_graceful);
 	g_test_add_func("/ns/sc_lock_unlock_ns_mutex",
 			test_sc_lock_unlock_ns_mutex);
 	g_test_add_func("/ns/sc_lock_ns_mutex/precondition",

--- a/src/ns-support.c
+++ b/src/ns-support.c
@@ -251,7 +251,8 @@ static struct sc_ns_group *sc_alloc_ns_group()
 	return group;
 }
 
-struct sc_ns_group *sc_open_ns_group(const char *group_name, const int flags)
+struct sc_ns_group *sc_open_ns_group(const char *group_name,
+				     const unsigned flags)
 {
 	struct sc_ns_group *group = sc_alloc_ns_group();
 	debug("opening namespace group directory %s", sc_ns_dir);

--- a/src/ns-support.h
+++ b/src/ns-support.h
@@ -49,23 +49,22 @@ void sc_initialize_ns_groups();
  */
 struct sc_ns_group;
 
+enum {
+	SC_NS_FAIL_GRACEFULLY = 1
+};
+
 /**
  * Open a namespace group.
  *
  * This will open and keep file descriptors for /run/snapd/ns/ as well as for
  * /run/snapd/ns/${group_name}.lock. The lock file is created if necessary but
  * is not locked until sc_lock_ns_mutex() is called.
- */
-struct sc_ns_group *sc_open_ns_group(const char *group_name);
-
-/**
- * Maybe open a namespace group.
  *
- * This function is just like sc_open_ns_group() except that it gracefully
- * handles the lack of the namespace group directory (/run/snapd/ns) and
- * returns NULL instead of aborting.
- **/
-struct sc_ns_group *sc_maybe_open_ns_group(const char *group_name)
+ * If the flags argument is SC_NS_FAIL_GRACEFULLY then the function returns
+ * NULL if the /run/snapd/ns directory doesn't exist. In all other cases it
+ * calls die() and exits the process.
+ */
+struct sc_ns_group *sc_open_ns_group(const char *group_name, const int flags);
 
 /**
  * Close namespace group.

--- a/src/ns-support.h
+++ b/src/ns-support.h
@@ -59,6 +59,15 @@ struct sc_ns_group;
 struct sc_ns_group *sc_open_ns_group(const char *group_name);
 
 /**
+ * Maybe open a namespace group.
+ *
+ * This function is just like sc_open_ns_group() except that it gracefully
+ * handles the lack of the namespace group directory (/run/snapd/ns) and
+ * returns NULL instead of aborting.
+ **/
+struct sc_ns_group *sc_maybe_open_ns_group(const char *group_name)
+
+/**
  * Close namespace group.
  *
  * This will close all of the open file descriptors and release allocated memory.

--- a/src/ns-support.h
+++ b/src/ns-support.h
@@ -64,7 +64,8 @@ enum {
  * NULL if the /run/snapd/ns directory doesn't exist. In all other cases it
  * calls die() and exits the process.
  */
-struct sc_ns_group *sc_open_ns_group(const char *group_name, const int flags);
+struct sc_ns_group *sc_open_ns_group(const char *group_name,
+				     const unsigned flags);
 
 /**
  * Close namespace group.

--- a/src/sc-main.c
+++ b/src/sc-main.c
@@ -88,7 +88,7 @@ int sc_main(int argc, char **argv)
 		}
 		sc_initialize_ns_groups();
 		struct sc_ns_group *group = NULL;
-		group = sc_open_ns_group(group_name);
+		group = sc_open_ns_group(group_name, 0);
 		sc_lock_ns_mutex(group);
 		sc_create_or_join_ns_group(group);
 		if (sc_should_populate_ns_group(group)) {

--- a/src/snap-discard-ns.c
+++ b/src/snap-discard-ns.c
@@ -23,7 +23,8 @@ int main(int argc, char **argv)
 	if (argc != 2)
 		die("Usage: %s snap-name", argv[0]);
 	const char *snap_name = argv[1];
-	struct sc_ns_group *group = sc_maybe_open_ns_group(snap_name);
+	struct sc_ns_group *group =
+	    sc_open_ns_group(snap_name, SC_NS_FAIL_GRACEFULLY);
 	if (group != NULL) {
 		sc_lock_ns_mutex(group);
 		sc_discard_preserved_ns_group(group);

--- a/src/snap-discard-ns.c
+++ b/src/snap-discard-ns.c
@@ -23,10 +23,12 @@ int main(int argc, char **argv)
 	if (argc != 2)
 		die("Usage: %s snap-name", argv[0]);
 	const char *snap_name = argv[1];
-	struct sc_ns_group *group = sc_open_ns_group(snap_name);
-	sc_lock_ns_mutex(group);
-	sc_discard_preserved_ns_group(group);
-	sc_unlock_ns_mutex(group);
-	sc_close_ns_group(group);
+	struct sc_ns_group *group = sc_maybe_open_ns_group(snap_name);
+	if (group != NULL) {
+		sc_lock_ns_mutex(group);
+		sc_discard_preserved_ns_group(group);
+		sc_unlock_ns_mutex(group);
+		sc_close_ns_group(group);
+	}
 	return 0;
 }


### PR DESCRIPTION
This patch changes snap-discard-ns to gracefully fail (as in, return
successfully) when any of the following three conditions happen:
- the /run/snapd/ns directory doesn't exist yet
- the /run/snapd/ns/$SNAP_NAME.mnt file doesn't exist
- the /run/snapd/ns/$SNAP_NAME.mnt file is not a mount point

This allows snapd to check for abnormal errors from snap-discard-ns.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
