### PR TITLE
add clone(CLONE_NEWUSER) test in spread-tests/regression/lp-1618683b

### DIFF
--- a/spread-tests/regression/lp-1618683b/task.yaml
+++ b/spread-tests/regression/lp-1618683b/task.yaml
@@ -1,0 +1,16 @@
+summary: Check that CLONE_NEWUSER works with clone() within snap apps
+# This is blacklisted on debian because we first have to get the dpkg-vendor patches
+systems: [-debian-8]
+details: |
+    Snap-confine used to "leak" the root filesystem directory across the
+    pivot_root call. This caused checks in the kernel to fail and resulted in
+    the inability to use clone(CLONE_NEWUSER) from snaps.
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+execute: |
+    cd /
+    echo "We can clone(CLONE_NEWUSER) as a regular user and expect it to work"
+    /snap/bin/snapd-hacker-toolbelt.busybox sh -c 'clone-newuser-test'
+restore: |
+    snap remove snapd-hacker-toolbelt


### PR DESCRIPTION
There is already a test for 'unshare -U' in spread-tests/regression/lp-1618683, but the fix for LP: #1618683 also fixed clone(CLONE_NEWUSER), so let's add a test for that. This requires merging https://code.launchpad.net/~jdstrand/+git/snapd-hacker-toolbelt/+ref/master.
