### PR TITLE
Fix /usr/src test to correctly clean up

### DIFF
--- a/spread-tests/regression/lp-1597842/task.yaml
+++ b/spread-tests/regression/lp-1597842/task.yaml
@@ -6,6 +6,7 @@ details: |
 prepare: |
     # NOTE: devmode is required because there's no interface for reading /usr/src/.canary
     snap install --devmode snapd-hacker-toolbelt
+    mv /usr/src /usr/src.orig || true
     mkdir -p /usr/src
     echo canary > /usr/src/.canary
 execute: |
@@ -15,4 +16,5 @@ execute: |
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -f /usr/src/.canary
-    rmdir /usr/src || true
+    rmdir /usr/src
+    mv /usr/src.orig /usr/src || true


### PR DESCRIPTION
The lp-1597842 regression test was found to incorrectly clean up after
itself by unconditionally removing /usr/src instead of restoring to
original directory. This would later cause failures because snap-confine
unconditionally mounts that directory and assumes it exists on the
classic filesystem.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
