### PR TITLE
Check the real alternatives directory in core_snap_dir

### DIFF
--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -312,11 +312,15 @@ static void setup_snappy_os_mounts()
 			      etc_alternatives);
 		must_snprintf(dst, sizeof dst, "%s%s", rootfs_dir,
 			      etc_alternatives);
-		debug("bind mounting %s to %s", src, dst);
-		// NOTE: MS_SLAVE so that the started process cannot maliciously mount
-		// anything into those places and affect the system on the outside.
-		if (mount(src, dst, NULL, MS_BIND | MS_SLAVE, NULL) != 0) {
-			die("cannot bind mount %s to %s", src, dst);
+		// We need check the real alternatives directory in core_snap_dir.
+		if (access(src, F_OK) != 0) {
+			debug("bind mounting %s to %s", src, dst);
+			// NOTE: MS_SLAVE so that the started process cannot maliciously mount
+			// anything into those places and affect the system on the outside.
+			if (mount(src, dst, NULL, MS_BIND | MS_SLAVE, NULL) !=
+			    0) {
+				die("cannot bind mount %s to %s", src, dst);
+			}
 		}
 	}
 	sc_mkdir_hostfs_if_missing();


### PR DESCRIPTION
We found an issue when run the snapd in BQ tablet device, it will bind /snap/ubuntu-core/current/etc/alternatives, but before that we don't check the user's permissions with access.
