### PR TITLE
Constrain SNAP_CONFINE_DEBUG values

### DIFF
--- a/src/utils-test.c
+++ b/src/utils-test.c
@@ -17,3 +17,48 @@
 
 #include "utils.h"
 #include "utils.c"
+
+#include <glib.h>
+
+static void test_str2bool()
+{
+	int err;
+	bool value;
+
+	err = str2bool("yes", &value);
+	g_assert_cmpint(err, ==, 0);
+	g_assert_true(value);
+
+	err = str2bool("1", &value);
+	g_assert_cmpint(err, ==, 0);
+	g_assert_true(value);
+
+	err = str2bool("no", &value);
+	g_assert_cmpint(err, ==, 0);
+	g_assert_false(value);
+
+	err = str2bool("0", &value);
+	g_assert_cmpint(err, ==, 0);
+	g_assert_false(value);
+
+	err = str2bool("", &value);
+	g_assert_cmpint(err, ==, 0);
+	g_assert_false(value);
+
+	err = str2bool(NULL, &value);
+	g_assert_cmpint(err, ==, 0);
+	g_assert_false(value);
+
+	err = str2bool("flower", &value);
+	g_assert_cmpint(err, ==, -1);
+	g_assert_cmpint(errno, ==, EINVAL);
+
+	err = str2bool("yes", NULL);
+	g_assert_cmpint(err, ==, -1);
+	g_assert_cmpint(errno, ==, EFAULT);
+}
+
+static void __attribute__ ((constructor)) init()
+{
+	g_test_add_func("/utils/str2bool", test_str2bool);
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -47,17 +47,80 @@ bool error(const char *msg, ...)
 	return false;
 }
 
+struct sc_bool_name {
+	const char *text;
+	bool value;
+};
+
+static const struct sc_bool_name sc_bool_names[] = {
+	{"yes", true},
+	{"no", false},
+	{"1", true},
+	{"0", false},
+	{"", false},
+};
+
+/**
+ * Convert string to a boolean value.
+ *
+ * The return value is 0 in case of success or -1 when the string cannot be
+ * converted correctly. In such case errno is set to indicate the problem and
+ * the value is not written back to the caller-supplied pointer.
+ **/
+static int str2bool(const char *text, bool * value)
+{
+	if (value == NULL) {
+		errno = EFAULT;
+		return -1;
+	}
+	if (text == NULL) {
+		*value = false;
+		return 0;
+	}
+	for (int i = 0; i < sizeof sc_bool_names / sizeof *sc_bool_names; ++i) {
+		if (strcmp(text, sc_bool_names[i].text) == 0) {
+			*value = sc_bool_names[i].value;
+			return 0;
+		}
+	}
+	errno = EINVAL;
+	return -1;
+}
+
+/**
+ * Get an environment variable and convert it to a boolean.
+ *
+ * Supported values are those of str2bool(), namely "yes", "no" as well as "1"
+ * and "0". All other values are treated as false and a diagnostic message is
+ * printed to stderr.
+ **/
+static bool getenv_bool(const char *name)
+{
+	const char *str_value = getenv(name);
+	bool value;
+	if (str2bool(str_value, &value) < 0) {
+		if (errno == EINVAL) {
+			fprintf(stderr,
+				"WARNING: unrecognized value of environment variable %s (expected yes/no or 1/0)\n",
+				name);
+			return false;
+		} else {
+			die("cannot convert value of environment variable %s to a boolean", name);
+		}
+	}
+	return value;
+}
+
 void debug(const char *msg, ...)
 {
-	if (getenv("SNAP_CONFINE_DEBUG") == NULL)
-		return;
-
-	va_list va;
-	va_start(va, msg);
-	fprintf(stderr, "DEBUG: ");
-	vfprintf(stderr, msg, va);
-	fprintf(stderr, "\n");
-	va_end(va);
+	if (getenv_bool("SNAP_CONFINE_DEBUG")) {
+		va_list va;
+		va_start(va, msg);
+		fprintf(stderr, "DEBUG: ");
+		vfprintf(stderr, msg, va);
+		fprintf(stderr, "\n");
+		va_end(va);
+	}
 }
 
 void write_string_to_file(const char *filepath, const char *buf)


### PR DESCRIPTION
This patch changes how the aforementioned environment variable is
interpreted. To have some sanity only a subset of values now triggers
the debugging semantics. Specifically only "yes" and "1" do so, other
values are handled gracefully (e.g. unset, empty, "no" or "0") and
finally all other values result in a diagnostic message.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
