### PR TITLE
Add mmap for nested containers on 4.8

### DIFF
--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -21,7 +21,7 @@
     /usr/lib/@{multiarch}/libseccomp.so* mr,
     /lib/@{multiarch}/libseccomp.so* mr,
 
-    @LIBEXECDIR@/snap-confine r,
+    @LIBEXECDIR@/snap-confine mr,
 
     /dev/null rw,
     /dev/full rw,

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -236,7 +236,7 @@
         /usr/lib/@{multiarch}/libseccomp.so* mr,
         /lib/@{multiarch}/libseccomp.so* mr,
 
-        @LIBEXECDIR@/snap-confine r,
+        @LIBEXECDIR@/snap-confine mr,
 
         /dev/null rw,
         /dev/full rw,


### PR DESCRIPTION
4.8+ kernels have a semantic change where the location of the mmap check in
the binfmt_elf loader changed along with the cred that is used for the check.
As a result, when using snap-confine in an LXD container that supports AppArmor
namespace stacking we must allow 'm' on @LIBEXECDIR@/snap-confine.
