### PR TITLE
Prefer the "core" snap is one is available.

### DIFF
--- a/spread-tests/main/core-is-preferred/task.yaml
+++ b/spread-tests/main/core-is-preferred/task.yaml
@@ -1,0 +1,7 @@
+summary: The snap named 'core' is preferred to the snap 'ubuntu-core'
+prepare: |
+    snap install --devmode snapd-hacker-toolbelt
+execute: |
+    snapd-hacker-toolbelt.busybox cat /meta/snap.yaml | grep -q -F 'name: core'
+restore: |
+    snap remove snapd-hacker-toolbelt

--- a/spread-tests/main/core-is-preferred/task.yaml
+++ b/spread-tests/main/core-is-preferred/task.yaml
@@ -1,7 +1,10 @@
 summary: The snap named 'core' is preferred to the snap 'ubuntu-core'
 prepare: |
     snap install --devmode snapd-hacker-toolbelt
+    snap install core
 execute: |
     snapd-hacker-toolbelt.busybox cat /meta/snap.yaml | grep -q -F 'name: core'
 restore: |
     snap remove snapd-hacker-toolbelt
+    # XXX: the core snap cannot be removed, we should use a trick to remove it
+    # in some other way but this can wait.

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -107,7 +107,7 @@
 
     # mount calls to setup the pivot_root based chroot with the core snap as
     # the root filesystem.
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/ubuntu-core/*/ -> /tmp/snap.rootfs_*/,
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/{ubuntu-,}core/*/ -> /tmp/snap.rootfs_*/,
 
     mount options=(rw rbind) /dev/ -> /tmp/snap.rootfs_*/dev/,
     mount options=(rw rbind) /etc/ -> /tmp/snap.rootfs_*/etc/,
@@ -125,7 +125,7 @@
     mount options=(rw rbind) {/usr,}/lib/modules/ -> /tmp/snap.rootfs_*/lib/modules/,
     mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
     mount options=(rw rbind) /usr/src/ -> /tmp/snap.rootfs_*/usr/src/,
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/ubuntu-core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/{ubuntu-,}core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
     # Allow to mkdir /var/lib/snapd/hostfs
     /var/lib/snapd/hostfs/ rw,
@@ -189,7 +189,7 @@
     /tmp/snapd.quirks_*/ rw,
     mount options=(move) /var/lib/snapd/ -> /tmp/snapd.quirks_*/,
     mount fstype=tmpfs options=(rw nodev nosuid) none -> /var/lib/,
-    mount options=(ro rbind) /snap/ubuntu-core/*/var/lib/** -> /var/lib/**,
+    mount options=(ro rbind) /snap/{ubuntu-,}core/*/var/lib/** -> /var/lib/**,
     umount /var/lib/snapd/,
     mount options=(move) /tmp/snapd.quirks_*/ -> /var/lib/snapd/,
 

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -107,7 +107,7 @@
 
     # mount calls to setup the pivot_root based chroot with the core snap as
     # the root filesystem.
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/{ubuntu-,}core/*/ -> /tmp/snap.rootfs_*/,
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/{,ubuntu-}core/*/ -> /tmp/snap.rootfs_*/,
 
     mount options=(rw rbind) /dev/ -> /tmp/snap.rootfs_*/dev/,
     mount options=(rw rbind) /etc/ -> /tmp/snap.rootfs_*/etc/,
@@ -125,7 +125,7 @@
     mount options=(rw rbind) {/usr,}/lib/modules/ -> /tmp/snap.rootfs_*/lib/modules/,
     mount options=(rw rbind) /var/log/ -> /tmp/snap.rootfs_*/var/log/,
     mount options=(rw rbind) /usr/src/ -> /tmp/snap.rootfs_*/usr/src/,
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/{ubuntu-,}core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/{,ubuntu-}core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
 
     # Allow to mkdir /var/lib/snapd/hostfs
     /var/lib/snapd/hostfs/ rw,
@@ -189,7 +189,7 @@
     /tmp/snapd.quirks_*/ rw,
     mount options=(move) /var/lib/snapd/ -> /tmp/snapd.quirks_*/,
     mount fstype=tmpfs options=(rw nodev nosuid) none -> /var/lib/,
-    mount options=(ro rbind) /snap/{ubuntu-,}core/*/var/lib/** -> /var/lib/**,
+    mount options=(ro rbind) /snap/{,ubuntu-}core/*/var/lib/** -> /var/lib/**,
     umount /var/lib/snapd/,
     mount options=(move) /tmp/snapd.quirks_*/ -> /var/lib/snapd/,
 


### PR DESCRIPTION
This patch allows the core snap to be named just "core" (instead of
ubuntu-core). The apparmor profile is updated to allow both directories
to be used.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1628612
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
