### PR TITLE
Set PATH unconditionally even if mount namespace is set up

### DIFF
--- a/spread-tests/regression/lp-1630479/task.yaml
+++ b/spread-tests/regression/lp-1630479/task.yaml
@@ -1,0 +1,21 @@
+summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1630479
+details: |
+    The PATH environment variable needs to make sense for the layout of the
+    core snap. Snap-confine contains code that sets it accordingly but during
+    the introduction of the namespace sharing feature that code would run only
+    when the namespace was initially constructed. Subsequent calls would not
+    see the correct path. 
+prepare: |
+    echo "Having installed the snapd-hacker-toolbelt snap"
+    snap install snapd-hacker-toolbelt
+execute: |
+    echo "We can observe the value of PATH twice"
+    one="$(snapd-hacker-toolbelt.busybox sh -c 'echo $PATH')"
+    two="$(snapd-hacker-toolbelt.busybox sh -c 'echo $PATH')"
+    echo "We can see that PATH is stable across calls"
+    [ "$one" = "$two" ]
+    echo "We can make sure that it has the right value"
+    # NOTE: [[ and == do pattern matching
+    [[ "$one" == /snap/snapd-hacker-toolbelt/*/bin:/snap/snapd-hacker-toolbelt/*/usr/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games ]]
+restore: |
+    snap remove snapd-hacker-toolbelt

--- a/spread-tests/regression/lp-1630479/task.yaml
+++ b/spread-tests/regression/lp-1630479/task.yaml
@@ -10,12 +10,12 @@ prepare: |
     snap install snapd-hacker-toolbelt
 execute: |
     echo "We can observe the value of PATH twice"
+    revision=$(readlink /snap/snapd-hacker-toolbelt/current)
     one="$(snapd-hacker-toolbelt.busybox sh -c 'echo $PATH')"
     two="$(snapd-hacker-toolbelt.busybox sh -c 'echo $PATH')"
     echo "We can see that PATH is stable across calls"
     [ "$one" = "$two" ]
     echo "We can make sure that it has the right value"
-    # NOTE: [[ and == do pattern matching
-    [[ "$one" == /snap/snapd-hacker-toolbelt/*/bin:/snap/snapd-hacker-toolbelt/*/usr/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games ]]
+    [ "$one" = "/snap/snapd-hacker-toolbelt/$revision/bin:/snap/snapd-hacker-toolbelt/$revision/usr/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games" ]
 restore: |
     snap remove snapd-hacker-toolbelt

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -349,13 +349,6 @@ static void setup_snappy_os_mounts()
 	sc_bind_mount_hostfs(rootfs_dir);
 	sc_mount_nvidia_driver(rootfs_dir);
 	sc_pivot_to_new_rootfs(rootfs_dir);
-	// Reset path as we cannot rely on the path from the host OS to
-	// make sense. The classic distribution may use any PATH that makes
-	// sense but we cannot assume it makes sense for the core snap
-	// layout. Note that the /usr/local directories are explicitly
-	// left out as they are not part of the core snap.
-	debug("resetting PATH to values in sync with core snap");
-	setenv("PATH", "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games", 1);
 }
 
 /**

--- a/src/sc-main.c
+++ b/src/sc-main.c
@@ -97,6 +97,13 @@ int sc_main(int argc, char **argv)
 		}
 		sc_unlock_ns_mutex(group);
 		sc_close_ns_group(group);
+		// Reset path as we cannot rely on the path from the host OS to
+		// make sense. The classic distribution may use any PATH that makes
+		// sense but we cannot assume it makes sense for the core snap
+		// layout. Note that the /usr/local directories are explicitly
+		// left out as they are not part of the core snap.
+		debug("resetting PATH to values in sync with core snap");
+		setenv("PATH", "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games", 1);
 		struct snappy_udev udev_s;
 		if (snappy_udev_init(security_tag, &udev_s) == 0)
 			setup_devices_cgroup(security_tag, &udev_s);


### PR DESCRIPTION
This patch corrects a bug where PATH would be correctly set only on the
first invocation of a given snap's application. After the first
invodation the mount namespace would be already initialized and the
relevant code that sets PATH would not run. Now this is corrected and
PATH is always set.

Fixes: https://bugs.launchpad.net/ubuntu/+source/snap-confine/+bug/1630479
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
