### PR TITLE
Allow running qemu spread tests offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# offline content
+spread-tests/offline-content/*.snap
+spread-tests/offline-content/xenial-amd64.tar.gz
+spread-tests/offline-content/packaging.*/
+
+# Build artefacts
 src/snap-confine
 src/snap-discard-ns
 src/snap-confine-unit-tests

--- a/spread-tests/distros/debian.common
+++ b/spread-tests/distros/debian.common
@@ -1,8 +1,4 @@
-if [ -n "${APT_PROXY:-}" ]; then
-    distro_archive=${APT_PROXY}/ftp.debian.org/debian
-else
-    distro_archive=http://ftp.debian.org/debian
-fi
+distro_archive=http://ftp.debian.org/debian
 # NOTE: Debian packaging needs to be updated. I sent a mail to the
 # debian maintainer with instructions on what needs to happen and
 # how it fits into the CI system.

--- a/spread-tests/distros/ubuntu.common
+++ b/spread-tests/distros/ubuntu.common
@@ -1,7 +1,3 @@
-if [ -n "${APT_PROXY:-}" ]; then
-    distro_archive=${APT_PROXY}/archive.ubuntu.com/ubuntu
-else
-    distro_archive=http://archive.ubuntu.com/ubuntu
-fi
+distro_archive=http://archive.ubuntu.com/ubuntu
 distro_packaging_git=https://git.launchpad.net/snap-confine
 sbuild_createchroot_extra="--components=main,universe"

--- a/spread-tests/main/cgroup-used/task.yaml
+++ b/spread-tests/main/cgroup-used/task.yaml
@@ -3,7 +3,7 @@ summary: Check that launcher cgroup functionality works
 systems: [-debian-8]
 prepare: |
     echo "Install snapd-hacker-toolbelt"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
 execute: |
     cd /
     echo "Clear udev tags and cgroups with non-test device and running snapd-hacker-toolbelt.busybox"

--- a/spread-tests/main/core-is-preferred/task.yaml
+++ b/spread-tests/main/core-is-preferred/task.yaml
@@ -1,7 +1,7 @@
 summary: The snap named 'core' is preferred to the snap 'ubuntu-core'
 prepare: |
-    snap install --devmode snapd-hacker-toolbelt
-    snap install core
+    "$SPREAD_PATH/spread-tests/snap-install" --devmode snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" core
 execute: |
     snapd-hacker-toolbelt.busybox cat /meta/snap.yaml | grep -q -F 'name: core'
 restore: |

--- a/spread-tests/main/hostfs-created-on-demand/task.yaml
+++ b/spread-tests/main/hostfs-created-on-demand/task.yaml
@@ -6,7 +6,7 @@ details: |
     if the host packaging of snapd doesn't already provide it.
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "We can move the packaged hostfs directory aside"
     if [ -d /var/lib/snapd/hostfs ]; then
         mv /var/lib/snapd/hostfs /var/lib/snapd/hostfs.orig

--- a/spread-tests/main/media-visible-in-devmode/task.yaml
+++ b/spread-tests/main/media-visible-in-devmode/task.yaml
@@ -3,7 +3,7 @@ summary: Check that /media is available to snaps installed in --devmode
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap in devmode"
-    snap install --devmode snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" --devmode snapd-hacker-toolbelt
     echo "Having added a canary file in /media"
     echo "test" > /media/canary
 execute: |

--- a/spread-tests/main/mount-ns-sharing/task.yaml
+++ b/spread-tests/main/mount-ns-sharing/task.yaml
@@ -5,7 +5,7 @@ details: |
     it is discarded with snap-discard-ns.
 prepare: |
     # NOTE: devmode is required because otherwise we cannot read /proc/self/ns/mnt
-    snap install --devmode snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" --devmode snapd-hacker-toolbelt
 execute: |
     export PATH=/snap/bin:$PATH
     echo "The mount namespace inside a snap is different"

--- a/spread-tests/main/mount-profiles-bin-snap-destination/task.yaml
+++ b/spread-tests/main/mount-profiles-bin-snap-destination/task.yaml
@@ -3,7 +3,7 @@ summary: Apparmor profile prevents bind-mounting to /snap/bin
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "We can change its mount profile externally to create bind mount /snap/bin somewhere"
     echo "/snap/snapd-hacker-toolbelt/mnt -> /snap/bin"
     mkdir -p /var/lib/snapd/mount
@@ -18,7 +18,7 @@ execute: |
     ! /snap/bin/snapd-hacker-toolbelt.busybox true
     sysctl -w kernel.printk_ratelimit=$orig_ratelimit
     echo "Not only the command failed because snap-confine failed, we see why!"
-    dmesg | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/bin/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/snapd-hacker-toolbelt/[0-9]\+/mnt/" flags="rw, bind"'
+    dmesg | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/bin/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/snapd-hacker-toolbelt/x\?[0-9]\+/mnt/" flags="rw, bind"'
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt

--- a/spread-tests/main/mount-profiles-bin-snap-source/task.yaml
+++ b/spread-tests/main/mount-profiles-bin-snap-source/task.yaml
@@ -3,7 +3,7 @@ summary: Apparmor profile prevents bind-mounting from /snap/bin
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "We can change its mount profile externally to create bind mount /snap/bin somewhere"
     echo "/snap/bin -> /snap/snapd-hacker-toolbelt/mnt"
     mkdir -p /var/lib/snapd/mount
@@ -18,7 +18,7 @@ execute: |
     ! /snap/bin/snapd-hacker-toolbelt.busybox true
     sysctl -w kernel.printk_ratelimit=$orig_ratelimit
     echo "Not only the command failed because snap-confine failed, we see why!"
-    dmesg | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/snapd-hacker-toolbelt/[0-9]\+/mnt/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/bin/" flags="rw, bind"'
+    dmesg | grep 'apparmor="DENIED" operation="mount" info="failed srcname match" error=-13 profile="/usr/lib/snapd/snap-confine" name="/snap/snapd-hacker-toolbelt/x\?[0-9]\+/mnt/" pid=[0-9]\+ comm="ubuntu-core-lau" srcname="/snap/bin/" flags="rw, bind"'
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt

--- a/spread-tests/main/mount-profiles-missing-dst/task.yaml
+++ b/spread-tests/main/mount-profiles-missing-dst/task.yaml
@@ -3,7 +3,7 @@ summary: Check that missing destination directory aborts mount processing
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "We can change its mount profile externally to create a read-only bind-mount"
     echo "/var/snap/snapd-hacker-toolbelt/common/src -> /var/snap/snapd-hacker-toolbelt/common/dst"
     mkdir -p /var/lib/snapd/mount

--- a/spread-tests/main/mount-profiles-missing-src/task.yaml
+++ b/spread-tests/main/mount-profiles-missing-src/task.yaml
@@ -3,7 +3,7 @@ summary: Check that missing source directory aborts mount processing
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "We can change its mount profile externally to create a read-only bind-mount"
     echo "/var/snap/snapd-hacker-toolbelt/common/src -> /var/snap/snapd-hacker-toolbelt/common/dst"
     mkdir -p /var/lib/snapd/mount

--- a/spread-tests/main/mount-profiles-mount-tmpfs/task.yaml
+++ b/spread-tests/main/mount-profiles-mount-tmpfs/task.yaml
@@ -1,14 +1,10 @@
 summary: Check that mount profiles cannot be used to mount tmpfs
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
-restore: |
-    snap remove snapd-hacker-toolbelt
-    rm -rf /var/snap/snapd-hacker-toolbelt
-    rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
-execute: |
+prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap list | grep -q snapd-hacker-toolbelt || snap install snapd-hacker-toolbelt
-
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
+execute: |
     echo "We can change its mount profile externally to mount tmpfs at /var/snap/snapd-hacker-toolbelt/mnt"
     mkdir -p /var/lib/snapd/mount
     echo "none /var/snap/snapd-hacker-toolbelt/common/mnt tmpfs rw 0 0" > /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab
@@ -18,3 +14,7 @@ execute: |
     
     echo "We can now run busybox.true and expect it to fail"
     ( cd / && ! /snap/bin/snapd-hacker-toolbelt.busybox true )
+restore: |
+    snap remove snapd-hacker-toolbelt
+    rm -rf /var/snap/snapd-hacker-toolbelt
+    rm -f /var/lib/snapd/mount/snap.snapd-hacker-toolbelt.busybox.fstab

--- a/spread-tests/main/mount-profiles-ro-mount/task.yaml
+++ b/spread-tests/main/mount-profiles-ro-mount/task.yaml
@@ -3,7 +3,7 @@ summary: Check that read-only bind mounts can be created
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "We can change its mount profile externally to create a read-only bind-mount"
     echo "/snap/snapd-hacker-toolbelt/current/src -> /snap/snapd-hacker-toolbelt/current/dst"
     mkdir -p /var/lib/snapd/mount

--- a/spread-tests/main/mount-profiles-rw-mount/task.yaml
+++ b/spread-tests/main/mount-profiles-rw-mount/task.yaml
@@ -3,7 +3,7 @@ summary: Check that read-write bind mounts can be created
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "We can connect it to the mount-observe slot from the core"
     snap connect snapd-hacker-toolbelt:mount-observe ubuntu-core:mount-observe
     echo "We can change its mount profile externally to create a read-only bind-mount"

--- a/spread-tests/main/mount-usr-src/task.yaml
+++ b/spread-tests/main/mount-usr-src/task.yaml
@@ -6,7 +6,7 @@ details: |
     from the host filesystem when running on a classic distribution.
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "and having connected the mount-observe interface"
     snap connect snapd-hacker-toolbelt:mount-observe ubuntu-core:mount-observe
 execute: |

--- a/spread-tests/main/test-snap-runs/task.yaml
+++ b/spread-tests/main/test-snap-runs/task.yaml
@@ -2,7 +2,7 @@ summary: Check that basic install works
 # This is blacklisted on debian because we first have to get the dpkg-vendor patches
 systems: [-debian-8]
 prepare: |
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
 execute: |
     cd /
     echo Run some hello-world stuff

--- a/spread-tests/main/user-data-dir-created/task.yaml
+++ b/spread-tests/main/user-data-dir-created/task.yaml
@@ -9,7 +9,7 @@ details: |
     This test checks that it is actually created
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "Having removed the SNAP_USER_DATA directory"
     rm -rf "$HOME/snap/snapd-hacker-toolbelt/"
 execute: |

--- a/spread-tests/offline-content/Makefile
+++ b/spread-tests/offline-content/Makefile
@@ -1,0 +1,44 @@
+required_snaps=hello-world snapd-hacker-toolbelt ubuntu-core core
+
+.PHONY: all
+all: $(addsuffix .snap,$(required_snaps)) $(addprefix packaging.,ubuntu)
+
+.PHONY: clean
+clean:
+	rm -f *.snap
+
+latest_revision_of_snap=$(lastword $(sort $(wildcard /var/lib/snapd/snaps/$(1)_*.snap)))
+
+.SECONDEXPANSION:
+
+# XXX: core.snap cannot be installed when you have ubuntu-core, get it directly from cdimage maybe
+
+%.snap: $$(call latest_revision_of_snap,%)
+	sudo ln $< $@
+	sudo chown $(shell id -u).$(shell id -g) $@
+
+packaging.ubuntu.git:
+	git clone --mirror https://git.launchpad.net/snap-confine packaging.ubuntu.git
+
+xenial-amd64.tar.gz: /var/lib/sbuild/xenial-amd64.tar.gz
+	sudo ln $< $@
+	sudo chown $(shell id -u).$(shell id -g) $@
+
+yakkety-amd64.tar.gz: /var/lib/sbuild/yakkety-amd64.tar.gz
+	sudo ln $< $@
+	sudo chown $(shell id -u).$(shell id -g) $@
+
+# NOTE: This assumes a working sbuild system
+/var/lib/sbuild/xenial-amd64.tar.gz:
+	sudo http_proxy=$(APT_PROXY) sbuild-createchroot \
+		--include=eatmydata \
+		--make-sbuild-tarball=/var/lib/sbuild/xenial-amd64.tar.gz \
+		--components=main,universe \
+		xenial $$(mktemp -d) http://archive.ubuntu.com/ubuntu
+
+/var/lib/sbuild/yakkety-amd64.tar.gz:
+	sudo http_proxy=$(APT_PROXY) sbuild-createchroot \
+		--include=eatmydata \
+		--make-sbuild-tarball=/var/lib/sbuild/yakkety-amd64.tar.gz \
+		--components=main,universe \
+		yakkety $$(mktemp -d) http://archive.ubuntu.com/ubuntu

--- a/spread-tests/offline-content/README
+++ b/spread-tests/offline-content/README
@@ -1,0 +1,25 @@
+This directory contains optional assets that given some additional configuration allow
+one to run spread tests completely offline. This is useful in certain situations, e.g.
+limited or metered connection, no network, etc.
+
+With the offline content in place tests run somewhat faster as one big part of the setup
+is skipped (sbuild-createchroot). The overal result is very much smilar / identical
+to if you were running online. In an emergency it is possible to convert your local online
+setup to work offline (just type 'make') but this requires that:
+
+ - you have working proxy for APT, e.g. apt-cacher-ng
+ - the proxy is used by your system so you have some useful content there
+   (edit /etc/apt/apt.conf.d/00proxy and insert something like
+    acquire::http::Proxy "http://192.168.9.1:3141";
+   this is easy to do if you use it for one full spread test in qemu
+ - the APT_PROXY environment variable points to the same URL as used above
+ - the IP address there is stable (ideally add it to your machine separately from
+   your normal dynamic address) and is available even when offline.
+ - you have the 'ubuntu-core', 'snapd-hacker-toolbelt' and 'hello-world' snaps installed
+   locally.
+ - you have sbuild set up and have appropriate chroots or can build one from your offline
+   proxy.
+
+Now all that you have to do is to put apt-cacher-ng into fully offline mode
+(/etc/apt-cacher-ng/acnf.conf has the appropriate switch). With everything else intact
+you should be able to type "make" here and end up with working offline spread tests.

--- a/spread-tests/regression/lp-1580018/task.yaml
+++ b/spread-tests/regression/lp-1580018/task.yaml
@@ -3,7 +3,7 @@ summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/15800
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
 execute: |
     cd /
     echo "We can check the inode number of /etc/alternatives" 

--- a/spread-tests/regression/lp-1595444/task.yaml
+++ b/spread-tests/regression/lp-1595444/task.yaml
@@ -16,7 +16,16 @@ execute: |
     echo "Then snap-confine moves us to /var/lib/snapd/void"
     [ "$(cd /foo && /snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "/var/lib/snapd/void" ]
     echo "And that directory is not readable or writable"
-    [ "$(cd /foo && /snap/bin/snapd-hacker-toolbelt.busybox ls 2>&1)" = "ls: .: Permission denied" ];
+    # NOTE: the printed message differs between dash and bash:
+    #
+    # In dash/busybox/sh it is:
+    # ls: .: Permission denied
+    #
+    # In bash it is:
+    # ls: cannot open directory '.': Permission denied
+    #
+    # The code below uses dash/sh
+    [ "$(cd /foo && /snap/bin/snapd-hacker-toolbelt.busybox sh -c 'ls' 2>&1)" = "ls: .: Permission denied" ];
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt

--- a/spread-tests/regression/lp-1595444/task.yaml
+++ b/spread-tests/regression/lp-1595444/task.yaml
@@ -6,7 +6,7 @@ details: |
     a directory that doesn't exist in the execution environment (chroot).
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     mkdir -p "/foo"
 execute: |
     echo "We can go to a location that is available in all snaps (/tmp)"
@@ -16,7 +16,7 @@ execute: |
     echo "Then snap-confine moves us to /var/lib/snapd/void"
     [ "$(cd /foo && /snap/bin/snapd-hacker-toolbelt.busybox pwd)" = "/var/lib/snapd/void" ]
     echo "And that directory is not readable or writable"
-    [ "$(cd /foo && /snap/bin/snapd-hacker-toolbelt.busybox ls 2>&1)" = "ls: can't open '.': Permission denied" ];
+    [ "$(cd /foo && /snap/bin/snapd-hacker-toolbelt.busybox ls 2>&1)" = "ls: .: Permission denied" ];
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -rf /var/snap/snapd-hacker-toolbelt

--- a/spread-tests/regression/lp-1597839/task.yaml
+++ b/spread-tests/regression/lp-1597839/task.yaml
@@ -6,7 +6,7 @@ details: |
     from the host filesystem when running on a classic distribution
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
 execute: |
     cd /
     echo "We can ensure that the /lib/modules/$(uname -r) directory exists"

--- a/spread-tests/regression/lp-1597842/task.yaml
+++ b/spread-tests/regression/lp-1597842/task.yaml
@@ -5,7 +5,7 @@ details: |
     access kernel sources.
 prepare: |
     # NOTE: devmode is required because there's no interface for reading /usr/src/.canary
-    snap install --devmode snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" --devmode snapd-hacker-toolbelt
     mv /usr/src /usr/src.orig || true
     mkdir -p /usr/src
     echo canary > /usr/src/.canary

--- a/spread-tests/regression/lp-1599608/task.yaml
+++ b/spread-tests/regression/lp-1599608/task.yaml
@@ -16,7 +16,7 @@ prepare: |
     exit 0
     cd /
     echo "Install hello-world"
-    snap install hello-world
+    "$SPREAD_PATH/spread-tests/snap-install" hello-world
     systemctl stop snapd.refresh.timer snapd.service snapd.socket
     # all of this ls madness can go away when we have remote environment
     # variables

--- a/spread-tests/regression/lp-1606277/task.yaml
+++ b/spread-tests/regression/lp-1606277/task.yaml
@@ -6,7 +6,7 @@ details: |
     even if the log-observe interface is being used.
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "And having connected the log-observe interface"
     snap connect snapd-hacker-toolbelt:log-observe ubuntu-core:log-observe
 execute: |

--- a/spread-tests/regression/lp-1607796/task.yaml
+++ b/spread-tests/regression/lp-1607796/task.yaml
@@ -3,7 +3,7 @@ summary: Check that /root is bind mounted to the real /root
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap in devmode"
-    snap install --devmode snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" --devmode snapd-hacker-toolbelt
     echo "Having added a canary file in /root"
     echo "test" > /root/canary
 execute: |

--- a/spread-tests/regression/lp-1613845/task.yaml
+++ b/spread-tests/regression/lp-1613845/task.yaml
@@ -8,7 +8,7 @@ details: |
     still important to ensure that it works in classic devmode environment.
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap in devmode"
-    snap install --devmode snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" --devmode snapd-hacker-toolbelt
     echo "Having created a canary file in /var/lib/lxd"
     mkdir -p /var/lib/lxd
     echo "test" > /var/lib/lxd/canary

--- a/spread-tests/regression/lp-1615113/task.yaml
+++ b/spread-tests/regression/lp-1615113/task.yaml
@@ -3,7 +3,7 @@ summary: Check that entire snap can be shared with the content interface
 systems: [-debian-8]
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
     echo "We can change its mount profile externally to create a read-only bind-mount"
     echo "/snap/snapd-hacker-toolbelt/current -> /snap/snapd-hacker-toolbelt/current/dst"
     mkdir -p /var/lib/snapd/mount/

--- a/spread-tests/regression/lp-1618683/task.yaml
+++ b/spread-tests/regression/lp-1618683/task.yaml
@@ -8,7 +8,7 @@ details: |
     devmode snaps.
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap in devmode"
-    snap install --devmode snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" --devmode snapd-hacker-toolbelt
 execute: |
     cd /
     echo "We can run unshare -U as a regular user and expect it to work"

--- a/spread-tests/regression/lp-1630479/task.yaml
+++ b/spread-tests/regression/lp-1630479/task.yaml
@@ -7,8 +7,9 @@ details: |
     see the correct path. 
 prepare: |
     echo "Having installed the snapd-hacker-toolbelt snap"
-    snap install snapd-hacker-toolbelt
+    "$SPREAD_PATH/spread-tests/snap-install" snapd-hacker-toolbelt
 execute: |
+    cd /
     echo "We can observe the value of PATH twice"
     revision=$(readlink /snap/snapd-hacker-toolbelt/current)
     one="$(snapd-hacker-toolbelt.busybox sh -c 'echo $PATH')"

--- a/spread-tests/snap-install
+++ b/spread-tests/snap-install
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Usage: snap-install [--devmode] SNAP"
+devmode=
+snapname=
+offline_path="$SPREAD_PATH/spread-tests/offline-content"
+while [ -n "$1" ]; do
+	case "$1" in
+		--devmode)
+			devmode="$1"
+			shift
+			;;
+		*)
+			snapname="$1"
+			shift
+			;;
+	esac
+done
+if [ -e "$offline_path/$snapname.snap" ]; then
+	echo "Using offline snap: $snapname"
+	snap install $devmode --force-dangerous "$offline_path/$snapname.snap"
+else
+	snap install $devmode $snapname
+fi

--- a/spread-tests/spread-prepare.sh
+++ b/spread-tests/spread-prepare.sh
@@ -103,7 +103,7 @@ EOF
                 "$distro_archive"
         fi
     fi
-    if [ -n "$APT_PROXY" ]; then
+    if [ -n "${APT_PROXY:-}" ]; then
         inject_proxy_cmd=--chroot-setup-commands="printf 'Acquire::http::Proxy \"$APT_PROXY\";\n' > /etc/apt/apt.conf.d/99proxy"
     else
         inject_proxy_cmd=--chroot-setup-commands=/bin/true

--- a/spread.yaml
+++ b/spread.yaml
@@ -11,23 +11,20 @@ backends:
             - ubuntu-16.04-64-grub
             # - ubuntu-16.04-32-grub
     qemu:
+        environment:
+            APT_PROXY: "$(HOST: echo $APT_PROXY)"
         systems:
             - ubuntu-16.04-64:
                 username: ubuntu
                 password: ubuntu
-                environment:
-                    APT_PROXY: "$(HOST: echo $APT_PROXY)"
-            - ubuntu-16.10-64:
-                username: ubuntu
-                password: ubuntu
-                environment:
-                    APT_PROXY: "$(HOST: echo $APT_PROXY)"
+        # NOTE: 16.10 is disabled because snapd is too old and the image ppa
+        # doesn't have yakkety packages. This needs to be re-enabled when snapd
+        # propagates
 
 path: /remote/path/
 
 exclude:
     - .git
-    - debian
     - autom4te.cache
 
 prepare: |


### PR DESCRIPTION
This patch allows spread tests to work offline. It requires some
explicit setup that is described in spread-tests/offline-content/README

The main motivator for this change is that it makes the testing cycle
work while on the plane/bus/train or where connectivity is limited or
unreliable. Even with reliable conncetion it can cut test time
significantly. On my relatively slow machine a full spread run for
xenial can now run in roughly 9 minutes. As a comparison, the same tests
ran on linode for nearly 11 minutes. I don't have hard numbers for
online tests on my machine (offline also makes some expensive operations
cached) but the initial time was closer to 20 minutes.

As a secondary factor testing is now a little bit more reproducible and
repatable. Spread makes ordering non-deterministic but at least package
building and snap revisions are fixed.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
