### PR TITLE
Add apparmor ptrace options for snap-confine

### DIFF
--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -252,7 +252,7 @@
     /run/snapd/ns/ rw,
     /run/snapd/ns/*.lock rwk,
     /run/snapd/ns/*.mnt rw,
-    ptrace (tracedby) peer=@LIBEXECDIR@/snap-confine//mount-namespace-capture-helper,
+    ptrace (read, readby, tracedby) peer=@LIBEXECDIR@/snap-confine//mount-namespace-capture-helper,
     @{PROC}/*/mountinfo r,
     capability sys_chroot,
     capability sys_admin,
@@ -319,7 +319,7 @@
         # This allows snap-confine to be killed from the outside.
         signal (receive) peer=unconfined,
         # This allows snap-confine to wait for us
-        ptrace (trace, tracedby) peer=@LIBEXECDIR@/snap-confine,
+        ptrace (read, trace, tracedby) peer=@LIBEXECDIR@/snap-confine,
     }
 
     # Allow snap-confine to be killed


### PR DESCRIPTION
Failed to run hello-world snap, the three missed options are reported in
kernel audit log.

Signed-off-by: You-Sheng Yang vicamo@gmail.com
