### PR TITLE
Make /writable unbindable

### DIFF
--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -325,6 +325,14 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		die("cannot perform operation: mount --make-unbindable %s",
 		    scratch_dir);
 	}
+	if (!config->on_classic) {
+		// Make the writable directory unbindable.
+		debug
+		    ("performing operation: mount --make-unbindable /writable");
+		if (mount("none", "/writable", NULL, MS_UNBINDABLE, NULL) < 0) {
+			die("cannot perform operation: mount --make-unbindable /writable");
+		}
+	}
 	// Recursively bind mount desired root filesystem directory over the
 	// scratch directory. This puts the initial content into the scratch space
 	// and serves as a foundation for all subsequent operations below.

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -89,6 +89,7 @@
     mount options=(rw rshared) -> /,
     mount options=(rw bind) /tmp/snap.rootfs_*/ -> /tmp/snap.rootfs_*/,
     mount options=(rw unbindable) -> /tmp/snap.rootfs_*/,
+    mount options=(rw unbindable) -> /writable/,
     # the next line is for clasic system
     mount options=(rw rbind) @SNAP_MOUNT_DIR@/{,ubuntu-}core/*/ -> /tmp/snap.rootfs_*/,
     # the next line is for core system


### PR DESCRIPTION
This patch fixes lp:1635194 by making /writable unbindable so that it
doesn't explode across the mount namespaces of individual snaps.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com
