### PR TITLE
add compatibility architectures for supported architectures (LP: #1592022)

### DIFF
--- a/spread-tests/main/test-seccomp-compat/task.yaml
+++ b/spread-tests/main/test-seccomp-compat/task.yaml
@@ -1,0 +1,13 @@
+summary: Check that basic install works
+# This is blacklisted on debian because we first have to get the dpkg-vendor patches
+systems: [-debian-8]
+prepare: |
+    snap install --edge test-seccomp-compat
+execute: |
+    cd /
+    echo Run the 64 bit binary
+    test-seccomp-compat.true64
+    echo Run the 32 bit binary
+    test-seccomp-compat.true32
+restore: |
+    snap remove test-seccomp-compat

--- a/src/seccomp-support.c
+++ b/src/seccomp-support.c
@@ -540,7 +540,7 @@ void sc_add_seccomp_archs(scmp_filter_ctx * ctx)
 
 	// For architectures that support a compat architecure, when the
 	// kernel and userspace match, add the compat arch, otherwise add
-	// the kernel arch to support the kerne's arch (eg, 64bit kernels with
+	// the kernel arch to support the kernel's arch (eg, 64bit kernels with
 	// 32bit userspace).
 	if (host_arch == native_arch) {
 		switch (host_arch) {

--- a/src/seccomp-support.c
+++ b/src/seccomp-support.c
@@ -536,14 +536,6 @@ void sc_add_seccomp_archs(scmp_filter_ctx * ctx)
 	debug("host arch (kernel) is '%d'", host_arch);
 	debug("native arch (userspace) is '%d'", native_arch);
 
-	// remove the SCMP_ARCH_NATIVE and add the native_arch. We do this so
-	// we can compare native_arch with host_arch below (since
-	// SCMP_ARCH_NATIVE != seccomp_arch_native())
-	if (seccomp_arch_remove(ctx, SCMP_ARCH_NATIVE) < 0)
-		die("seccomp_arch_remove(..., SCMP_ARCH_NATIVE) failed");
-	if (seccomp_arch_add(ctx, native_arch) < 0)
-		die("seccomp_arch_add(..., native_arch) failed");
-
 	// For architectures that support a compat architecure, when the
 	// kernel and userspace match, add the compat arch, otherwise add
 	// the kernel arch to support 64bit kernels with 32bit userspace.

--- a/src/seccomp-support.c
+++ b/src/seccomp-support.c
@@ -524,6 +524,8 @@ uint32_t get_hostarch(void)
 	else if (strncmp(uts.machine, "s390x", 5) == 0)
 		return SCMP_ARCH_S390X;
 
+	// Just return the seccomp userspace native arch if we can't detect the
+	// kernel host arch.
 	return seccomp_arch_native();
 }
 
@@ -538,7 +540,8 @@ void sc_add_seccomp_archs(scmp_filter_ctx * ctx)
 
 	// For architectures that support a compat architecure, when the
 	// kernel and userspace match, add the compat arch, otherwise add
-	// the kernel arch to support 64bit kernels with 32bit userspace.
+	// the kernel arch to support the kerne's arch (eg, 64bit kernels with
+	// 32bit userspace).
 	if (host_arch == native_arch) {
 		switch (host_arch) {
 		case SCMP_ARCH_X86_64:


### PR DESCRIPTION
Add get_hostarch() (inspired by lxc codebase) to determine the host (kernel) architecture. For architectures that support it, then add the compatibility arch using seccomp_arch_add(). Account for 64 bit kernel/userspace, 32 bit kernel/usespace and 64 bit kernel with 32 bit userspace. When syscalls are
added later, they will be added for each added architecture. Eg:
- with amd64 kernel and userspace, add x86 architecture so that both 64 bit and 32 bit binaries can be used
- with i386 kernel and userspace, add only the x86 architecture so only 32 bit binaries are supported
- with amd64 kernel and i386 userspace, add the x86_64 architecture so that both 32 bit and 64 bit binaries can be used