### PR TITLE
allow 'mr' access to libdl-*.so (LP: #1634394)

### DIFF
--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -14,6 +14,7 @@
     # normal libs in order
     /lib/@{multiarch}/libapparmor.so* mr,
     /lib/@{multiarch}/libcgmanager.so* mr,
+    /lib/@{multiarch}/libdl-[0-9]*.so* mr,
     /lib/@{multiarch}/libnih.so* mr,
     /lib/@{multiarch}/libnih-dbus.so* mr,
     /lib/@{multiarch}/libdbus-1.so* mr,


### PR DESCRIPTION
This was reported against yakkety and we have yakkety spread tests, so not sure why we didn't see it there, but the access is fine for everywhere.