### PR TITLE
Detach the hostfs version of /dev

### DIFF
--- a/spread-tests/main/mount-ns-layout/expected.classic.core.json
+++ b/spread-tests/main/mount-ns-layout/expected.classic.core.json
@@ -608,56 +608,6 @@
     "root_dir": "/var/lib/snapd/hostfs"
   },
   {
-    "fs_type": "devtmpfs",
-    "mount_opts": "rw,nosuid,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev",
-    "mount_src": "udev",
-    "opt_fields": [
-      "master:renumbered/1"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "hugetlbfs",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev/hugepages",
-    "mount_src": "hugetlbfs",
-    "opt_fields": [
-      "master:renumbered/2"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "mqueue",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev/mqueue",
-    "mount_src": "mqueue",
-    "opt_fields": [
-      "master:renumbered/3"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "devpts",
-    "mount_opts": "rw,nosuid,noexec,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev/pts",
-    "mount_src": "devpts",
-    "opt_fields": [
-      "master:renumbered/4"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "tmpfs",
-    "mount_opts": "rw,nosuid,nodev",
-    "mount_point": "/var/lib/snapd/hostfs/dev/shm",
-    "mount_src": "tmpfs",
-    "opt_fields": [
-      "master:renumbered/5"
-    ],
-    "root_dir": "/"
-  },
-  {
     "fs_type": "proc",
     "mount_opts": "rw,nosuid,nodev,noexec,relatime",
     "mount_point": "/var/lib/snapd/hostfs/proc",

--- a/spread-tests/main/mount-ns-layout/expected.classic.ubuntu-core.json
+++ b/spread-tests/main/mount-ns-layout/expected.classic.ubuntu-core.json
@@ -618,56 +618,6 @@
     "root_dir": "/var/lib/snapd/hostfs"
   },
   {
-    "fs_type": "devtmpfs",
-    "mount_opts": "rw,nosuid,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev",
-    "mount_src": "udev",
-    "opt_fields": [
-      "master:renumbered/1"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "hugetlbfs",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev/hugepages",
-    "mount_src": "hugetlbfs",
-    "opt_fields": [
-      "master:renumbered/2"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "mqueue",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev/mqueue",
-    "mount_src": "mqueue",
-    "opt_fields": [
-      "master:renumbered/3"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "devpts",
-    "mount_opts": "rw,nosuid,noexec,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev/pts",
-    "mount_src": "devpts",
-    "opt_fields": [
-      "master:renumbered/4"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "tmpfs",
-    "mount_opts": "rw,nosuid,nodev",
-    "mount_point": "/var/lib/snapd/hostfs/dev/shm",
-    "mount_src": "tmpfs",
-    "opt_fields": [
-      "master:renumbered/5"
-    ],
-    "root_dir": "/"
-  },
-  {
     "fs_type": "proc",
     "mount_opts": "rw,nosuid,nodev,noexec,relatime",
     "mount_point": "/var/lib/snapd/hostfs/proc",

--- a/spread-tests/main/mount-ns-layout/expected.core.json
+++ b/spread-tests/main/mount-ns-layout/expected.core.json
@@ -960,56 +960,6 @@
     "root_dir": "/EFI/ubuntu"
   },
   {
-    "fs_type": "devtmpfs",
-    "mount_opts": "rw,nosuid,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev",
-    "mount_src": "udev",
-    "opt_fields": [
-      "master:renumbered/2"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "hugetlbfs",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev/hugepages",
-    "mount_src": "hugetlbfs",
-    "opt_fields": [
-      "master:renumbered/3"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "mqueue",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev/mqueue",
-    "mount_src": "mqueue",
-    "opt_fields": [
-      "master:renumbered/4"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "devpts",
-    "mount_opts": "rw,nosuid,noexec,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/dev/pts",
-    "mount_src": "devpts",
-    "opt_fields": [
-      "master:renumbered/5"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "tmpfs",
-    "mount_opts": "rw,nosuid,nodev",
-    "mount_point": "/var/lib/snapd/hostfs/dev/shm",
-    "mount_src": "tmpfs",
-    "opt_fields": [
-      "master:renumbered/6"
-    ],
-    "root_dir": "/"
-  },
-  {
     "fs_type": "ext4",
     "mount_opts": "rw,relatime",
     "mount_point": "/var/lib/snapd/hostfs/etc/apparmor.d/cache",

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -503,6 +503,13 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	if (umount2(src, UMOUNT_NOFOLLOW | MNT_DETACH) < 0) {
 		die("cannot perform operation: umount --lazy %s", src);
 	}
+	// Detach the redundant hostfs version of /dev since it shows up in the
+	// mount table and software inspecting the mount table may become confused.
+	must_snprintf(src, sizeof src, "%s/dev", SC_HOSTFS_DIR);
+	debug("performing operation: umount --lazy %s", src);
+	if (umount2(src, UMOUNT_NOFOLLOW | MNT_DETACH) < 0) {
+		die("cannot perform operation: umount --lazy %s", src);
+	}
 }
 
 /**

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -157,6 +157,7 @@
     # cleanup 
     umount /var/lib/snapd/hostfs/tmp/snap.rootfs_*/,
     umount /var/lib/snapd/hostfs/sys/,
+    umount /var/lib/snapd/hostfs/dev/,
     mount options=(rw rslave) -> /var/lib/snapd/hostfs/,
 
     # set up snap-specific private /tmp dir


### PR DESCRIPTION
This patch detaches (aka umount --lazy) or umount2(1) with MNT_DETACH flag the
second /dev that is visible from /var/lib/snapd/hostfs/dev after the pivot_root
call.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>