### PR TITLE
Detach the hostfs version of /proc

### DIFF
--- a/spread-tests/main/mount-ns-layout/expected.classic.core.json
+++ b/spread-tests/main/mount-ns-layout/expected.classic.core.json
@@ -608,26 +608,6 @@
     "root_dir": "/var/lib/snapd/hostfs"
   },
   {
-    "fs_type": "proc",
-    "mount_opts": "rw,nosuid,nodev,noexec,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/proc",
-    "mount_src": "proc",
-    "opt_fields": [
-      "master:renumbered/8"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "autofs",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/proc/sys/fs/binfmt_misc",
-    "mount_src": "systemd-1",
-    "opt_fields": [
-      "master:renumbered/9"
-    ],
-    "root_dir": "/"
-  },
-  {
     "fs_type": "tmpfs",
     "mount_opts": "rw,nosuid,noexec,relatime",
     "mount_point": "/var/lib/snapd/hostfs/run",

--- a/spread-tests/main/mount-ns-layout/expected.classic.ubuntu-core.json
+++ b/spread-tests/main/mount-ns-layout/expected.classic.ubuntu-core.json
@@ -618,26 +618,6 @@
     "root_dir": "/var/lib/snapd/hostfs"
   },
   {
-    "fs_type": "proc",
-    "mount_opts": "rw,nosuid,nodev,noexec,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/proc",
-    "mount_src": "proc",
-    "opt_fields": [
-      "master:renumbered/8"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "autofs",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/proc/sys/fs/binfmt_misc",
-    "mount_src": "systemd-1",
-    "opt_fields": [
-      "master:renumbered/9"
-    ],
-    "root_dir": "/"
-  },
-  {
     "fs_type": "tmpfs",
     "mount_opts": "rw,nosuid,noexec,relatime",
     "mount_point": "/var/lib/snapd/hostfs/run",

--- a/spread-tests/main/mount-ns-layout/expected.core.json
+++ b/spread-tests/main/mount-ns-layout/expected.core.json
@@ -1260,36 +1260,6 @@
     "root_dir": "/"
   },
   {
-    "fs_type": "proc",
-    "mount_opts": "rw,nosuid,nodev,noexec,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/proc",
-    "mount_src": "proc",
-    "opt_fields": [
-      "master:renumbered/38"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "binfmt_misc",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/proc/sys/fs/binfmt_misc",
-    "mount_src": "binfmt_misc",
-    "opt_fields": [
-      "master:renumbered/40"
-    ],
-    "root_dir": "/"
-  },
-  {
-    "fs_type": "autofs",
-    "mount_opts": "rw,relatime",
-    "mount_point": "/var/lib/snapd/hostfs/proc/sys/fs/binfmt_misc",
-    "mount_src": "systemd-1",
-    "opt_fields": [
-      "master:renumbered/39"
-    ],
-    "root_dir": "/"
-  },
-  {
     "fs_type": "ext4",
     "mount_opts": "rw,relatime",
     "mount_point": "/var/lib/snapd/hostfs/root",

--- a/src/mount-support.c
+++ b/src/mount-support.c
@@ -510,6 +510,13 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	if (umount2(src, UMOUNT_NOFOLLOW | MNT_DETACH) < 0) {
 		die("cannot perform operation: umount --lazy %s", src);
 	}
+	// Detach the redundant hostfs version of /proc since it shows up in the
+	// mount table and software inspecting the mount table may become confused.
+	must_snprintf(src, sizeof src, "%s/proc", SC_HOSTFS_DIR);
+	debug("performing operation: umount --lazy %s", src);
+	if (umount2(src, UMOUNT_NOFOLLOW | MNT_DETACH) < 0) {
+		die("cannot perform operation: umount --lazy %s", src);
+	}
 }
 
 /**

--- a/src/snap-confine.apparmor.in
+++ b/src/snap-confine.apparmor.in
@@ -158,6 +158,7 @@
     umount /var/lib/snapd/hostfs/tmp/snap.rootfs_*/,
     umount /var/lib/snapd/hostfs/sys/,
     umount /var/lib/snapd/hostfs/dev/,
+    umount /var/lib/snapd/hostfs/proc/,
     mount options=(rw rslave) -> /var/lib/snapd/hostfs/,
 
     # set up snap-specific private /tmp dir


### PR DESCRIPTION
This patch detaches (aka umount --lazy) or umount2(1) with MNT_DETACH
flag the second /proc that is visible from /var/lib/snapd/hostfs/proc
after the pivot_root call.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>