### PR TITLE
Add apparmor support module

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,7 +61,9 @@ snap_confine_SOURCES = \
 	mountinfo.c \
 	mountinfo.h \
 	ns-support.c \
-	ns-support.h
+	ns-support.h \
+	apparmor-support.c \
+	apparmor-support.h
 
 snap_confine_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_confine_LDFLAGS = $(AM_LDFLAGS)

--- a/src/apparmor-support.c
+++ b/src/apparmor-support.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "apparmor-support.h"
+
+#include <stdbool.h>
+#include <string.h>
+#ifdef HAVE_APPARMOR
+#include <sys/apparmor.h>
+#endif				// ifdef HAVE_APPARMOR
+
+#include "cleanup-funcs.h"
+#include "utils.h"
+
+// NOTE: Those constants map exactly what apparmor is returning and cannot be
+// changed without breaking apparmor functionality.
+#define SC_AA_ENFORCE_STR "enforce"
+#define SC_AA_COMPLAIN_STR "complain"
+
+enum sc_mode {
+	// The enforcement mode was not recognized.
+	SC_AA_INVALID = -1,
+	// The enforcement mode is not applicable because apparmor is disabled.
+	SC_AA_NOT_APPLICABLE = 0,
+	// The enforcement mode is "enforcing"
+	SC_AA_ENFORCE = 1,
+	// The enforcement mode is "complain"
+	SC_AA_COMPLAIN,
+};
+
+struct sc_apparmor {
+	// The mode of enforcement. In addition to the two apparmor defined modes
+	// can be also SC_AA_INVALID (unknown mode reported by apparmor) and
+	// SC_AA_NOT_APPLICABLE (when we're not linked with apparmor).
+	enum sc_mode mode;
+	// Flag indicating that the current process is confined.
+	bool is_confined;
+};
+
+void sc_init_apparmor_support(struct sc_apparmor *apparmor)
+{
+#ifdef HAVE_APPARMOR
+	char *label __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *mode = NULL;	// mode cannot be free'd
+	if (aa_getcon(&label, &mode) < 0) {
+		die("cannot query current apparmor profile");
+	}
+	// Look at label, if it is non empty then we are confined. 
+	if (strcmp(label, "") != 0) {
+		apparmor->is_confined = true;
+	} else {
+		apparmor->is_confined = false;
+	}
+	// Look at mode, it must be one of the well known strings.
+	if (strcmp(mode, SC_AA_COMPLAIN_STR) == 0) {
+		apparmor->mode = SC_AA_COMPLAIN;
+	} else if (strcmp(mode, SC_AA_ENFORCE_STR) == 0) {
+		apparmor->mode = SC_AA_ENFORCE;
+	} else {
+		apparmor->mode = SC_AA_INVALID;
+	}
+#else
+	apparmor->mode = SC_AA_NOT_APPLICABLE;
+	apparmor->is_confined = false;
+#endif				// ifdef HAVE_APPARMOR
+}
+
+void
+sc_maybe_aa_change_onexec(struct sc_apparmor *apparmor, const char *profile)
+{
+#ifdef HAVE_APPARMOR
+	debug("requesting changing of apparmor profile on next exec to %s",
+	      profile);
+	if (aa_change_onexec(profile) < 0) {
+		if (secure_getenv("SNAPPY_LAUNCHER_INSIDE_TESTS") == NULL) {
+			die("cannot change profile for the next exec call");
+		}
+	}
+#endif				// ifdef HAVE_APPARMOR
+}
+
+void
+sc_maybe_aa_change_hat(struct sc_apparmor *apparmor,
+		       const char *subprofile, unsigned long magic_token)
+{
+#ifdef HAVE_APPARMOR
+	if (apparmor->is_confined) {
+		debug("changing apparmor hat to %s", subprofile);
+		if (aa_change_hat(subprofile, magic_token) < 0) {
+			die("cannot change apparmor hat");
+		}
+	}
+#endif				// ifdef HAVE_APPARMOR
+}

--- a/src/apparmor-support.c
+++ b/src/apparmor-support.c
@@ -43,15 +43,15 @@ void sc_init_apparmor_support(struct sc_apparmor *apparmor)
 		die("cannot query current apparmor profile");
 	}
 	// Look at label, if it is non empty then we are confined. 
-	if (strcmp(label, "") != 0) {
+	if (label != NULL && strcmp(label, "") != 0) {
 		apparmor->is_confined = true;
 	} else {
 		apparmor->is_confined = false;
 	}
 	// Look at mode, it must be one of the well known strings.
-	if (strcmp(mode, SC_AA_COMPLAIN_STR) == 0) {
+	if (mode != NULL && strcmp(mode, SC_AA_COMPLAIN_STR) == 0) {
 		apparmor->mode = SC_AA_COMPLAIN;
-	} else if (strcmp(mode, SC_AA_ENFORCE_STR) == 0) {
+	} else if (mode != NULL && strcmp(mode, SC_AA_ENFORCE_STR) == 0) {
 		apparmor->mode = SC_AA_ENFORCE;
 	} else {
 		apparmor->mode = SC_AA_INVALID;

--- a/src/apparmor-support.c
+++ b/src/apparmor-support.c
@@ -33,6 +33,7 @@
 // changed without breaking apparmor functionality.
 #define SC_AA_ENFORCE_STR "enforce"
 #define SC_AA_COMPLAIN_STR "complain"
+#define SC_AA_UNCONFINED_STR "unconfined"
 
 void sc_init_apparmor_support(struct sc_apparmor *apparmor)
 {
@@ -43,7 +44,7 @@ void sc_init_apparmor_support(struct sc_apparmor *apparmor)
 		die("cannot query current apparmor profile");
 	}
 	// Look at label, if it is non empty then we are confined. 
-	if (label != NULL && strcmp(label, "") != 0) {
+	if (label != NULL && strcmp(label, SC_AA_UNCONFINED_STR) != 0) {
 		apparmor->is_confined = true;
 	} else {
 		apparmor->is_confined = false;

--- a/src/apparmor-support.c
+++ b/src/apparmor-support.c
@@ -22,6 +22,7 @@
 #include "apparmor-support.h"
 
 #include <string.h>
+#include <errno.h>
 #ifdef HAVE_APPARMOR
 #include <sys/apparmor.h>
 #endif				// ifdef HAVE_APPARMOR
@@ -39,18 +40,54 @@
 void sc_init_apparmor_support(struct sc_apparmor *apparmor)
 {
 #ifdef HAVE_APPARMOR
+	// Use aa_is_enabled() to see if apparmor is available in the kernel and
+	// enabled at boot time. If it isn't log a diagnostic message and assume
+	// we're not confined.
+	if (aa_is_enabled() != true) {
+		switch (errno) {
+		case ENOSYS:
+			debug
+			    ("apparmor extensions to the system are not available");
+			break;
+		case ECANCELED:
+			debug
+			    ("apparmor is available on the system but has been disabled at boot");
+			break;
+		case ENOENT:
+			debug
+			    ("apparmor is available but the interface but the interface is not available");
+		case EPERM:
+			// NOTE: fall-through
+		case EACCES:
+			debug
+			    ("insufficient permissions to determine if apparmor is enabled");
+			break;
+		default:
+			debug("apparmor is not enabled: %s", strerror(errno));
+			break;
+		}
+		apparmor->is_confined = false;
+		apparmor->mode = SC_AA_NOT_APPLICABLE;
+		return;
+	}
+	// Use aa_getcon() to check the label of the current process and
+	// confinement type. Note that the returned label must be released with
+	// free() but the mode is a constant string that must not be freed.
 	char *label __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
-	char *mode = NULL;	// mode cannot be free'd
+	char *mode = NULL;
 	if (aa_getcon(&label, &mode) < 0) {
 		die("cannot query current apparmor profile");
 	}
-	// Look at label, if it is non empty then we are confined. 
-	if (label != NULL && strcmp(label, SC_AA_UNCONFINED_STR) != 0) {
-		apparmor->is_confined = true;
-	} else {
+	// The label has a special value "unconfined" that is applied to all
+	// processes without a dedicated profile. If that label is used then the
+	// current process is not confined. All other labels imply confinement.
+	if (label != NULL && strcmp(label, SC_AA_UNCONFINED_STR) == 0) {
 		apparmor->is_confined = false;
+	} else {
+		apparmor->is_confined = true;
 	}
-	// Look at mode, it must be one of the well known strings.
+	// There are several possible results for the confinement type (mode) that
+	// are checked for below.
 	if (mode != NULL && strcmp(mode, SC_AA_COMPLAIN_STR) == 0) {
 		apparmor->mode = SC_AA_COMPLAIN;
 	} else if (mode != NULL && strcmp(mode, SC_AA_ENFORCE_STR) == 0) {

--- a/src/apparmor-support.c
+++ b/src/apparmor-support.c
@@ -33,6 +33,7 @@
 // changed without breaking apparmor functionality.
 #define SC_AA_ENFORCE_STR "enforce"
 #define SC_AA_COMPLAIN_STR "complain"
+#define SC_AA_MIXED_STR "mixed"
 #define SC_AA_UNCONFINED_STR "unconfined"
 
 void sc_init_apparmor_support(struct sc_apparmor *apparmor)
@@ -54,6 +55,8 @@ void sc_init_apparmor_support(struct sc_apparmor *apparmor)
 		apparmor->mode = SC_AA_COMPLAIN;
 	} else if (mode != NULL && strcmp(mode, SC_AA_ENFORCE_STR) == 0) {
 		apparmor->mode = SC_AA_ENFORCE;
+	} else if (mode != NULL && strcmp(mode, SC_AA_MIXED_STR) == 0) {
+		apparmor->mode = SC_AA_MIXED;
 	} else {
 		apparmor->mode = SC_AA_INVALID;
 	}

--- a/src/apparmor-support.c
+++ b/src/apparmor-support.c
@@ -21,7 +21,6 @@
 
 #include "apparmor-support.h"
 
-#include <stdbool.h>
 #include <string.h>
 #ifdef HAVE_APPARMOR
 #include <sys/apparmor.h>
@@ -34,26 +33,6 @@
 // changed without breaking apparmor functionality.
 #define SC_AA_ENFORCE_STR "enforce"
 #define SC_AA_COMPLAIN_STR "complain"
-
-enum sc_apparmor_mode {
-	// The enforcement mode was not recognized.
-	SC_AA_INVALID = -1,
-	// The enforcement mode is not applicable because apparmor is disabled.
-	SC_AA_NOT_APPLICABLE = 0,
-	// The enforcement mode is "enforcing"
-	SC_AA_ENFORCE = 1,
-	// The enforcement mode is "complain"
-	SC_AA_COMPLAIN,
-};
-
-struct sc_apparmor {
-	// The mode of enforcement. In addition to the two apparmor defined modes
-	// can be also SC_AA_INVALID (unknown mode reported by apparmor) and
-	// SC_AA_NOT_APPLICABLE (when we're not linked with apparmor).
-	enum sc_apparmor_mode mode;
-	// Flag indicating that the current process is confined.
-	bool is_confined;
-};
 
 void sc_init_apparmor_support(struct sc_apparmor *apparmor)
 {

--- a/src/apparmor-support.c
+++ b/src/apparmor-support.c
@@ -35,7 +35,7 @@
 #define SC_AA_ENFORCE_STR "enforce"
 #define SC_AA_COMPLAIN_STR "complain"
 
-enum sc_mode {
+enum sc_apparmor_mode {
 	// The enforcement mode was not recognized.
 	SC_AA_INVALID = -1,
 	// The enforcement mode is not applicable because apparmor is disabled.
@@ -50,7 +50,7 @@ struct sc_apparmor {
 	// The mode of enforcement. In addition to the two apparmor defined modes
 	// can be also SC_AA_INVALID (unknown mode reported by apparmor) and
 	// SC_AA_NOT_APPLICABLE (when we're not linked with apparmor).
-	enum sc_mode mode;
+	enum sc_apparmor_mode mode;
 	// Flag indicating that the current process is confined.
 	bool is_confined;
 };

--- a/src/apparmor-support.h
+++ b/src/apparmor-support.h
@@ -73,7 +73,7 @@ void sc_init_apparmor_support(struct sc_apparmor *apparmor);
  * environment variable is set then the process is not terminated.
  **/
 void
-sc_maybe_aa_chagne_onexec(struct sc_apparmor *apparmor, const char *profile);
+sc_maybe_aa_change_onexec(struct sc_apparmor *apparmor, const char *profile);
 
 /**
  * Maybe call aa_change_hat(2)

--- a/src/apparmor-support.h
+++ b/src/apparmor-support.h
@@ -85,7 +85,7 @@ sc_maybe_aa_chagne_onexec(struct sc_apparmor *apparmor, const char *profile);
  * process termination.
  **/
 void
-sc_maybe_change_apparmor_hat(struct sc_apparmor *apparmor,
-			     const char *subprofile, unsigned long magic_token);
+sc_maybe_aa_change_hat(struct sc_apparmor *apparmor,
+		       const char *subprofile, unsigned long magic_token)
 
 #endif

--- a/src/apparmor-support.h
+++ b/src/apparmor-support.h
@@ -32,6 +32,8 @@ enum sc_apparmor_mode {
 	SC_AA_ENFORCE = 1,
 	// The enforcement mode is "complain"
 	SC_AA_COMPLAIN,
+	// The enforcement mode is "mixed"
+	SC_AA_MIXED,
 };
 
 /**

--- a/src/apparmor-support.h
+++ b/src/apparmor-support.h
@@ -18,10 +18,30 @@
 #ifndef SNAP_CONFINE_APPARMOR_SUPPORT_H
 #define SNAP_CONFINE_APPARMOR_SUPPORT_H
 
+#include <stdbool.h>
+
 /**
  * Data required to manage apparmor wrapper. 
  */
-struct sc_apparmor;
+enum sc_apparmor_mode {
+	// The enforcement mode was not recognized.
+	SC_AA_INVALID = -1,
+	// The enforcement mode is not applicable because apparmor is disabled.
+	SC_AA_NOT_APPLICABLE = 0,
+	// The enforcement mode is "enforcing"
+	SC_AA_ENFORCE = 1,
+	// The enforcement mode is "complain"
+	SC_AA_COMPLAIN,
+};
+
+struct sc_apparmor {
+	// The mode of enforcement. In addition to the two apparmor defined modes
+	// can be also SC_AA_INVALID (unknown mode reported by apparmor) and
+	// SC_AA_NOT_APPLICABLE (when we're not linked with apparmor).
+	enum sc_apparmor_mode mode;
+	// Flag indicating that the current process is confined.
+	bool is_confined;
+};
 
 /**
  * Initialize apparmor support.

--- a/src/apparmor-support.h
+++ b/src/apparmor-support.h
@@ -21,8 +21,8 @@
 #include <stdbool.h>
 
 /**
- * Data required to manage apparmor wrapper. 
- */
+ * Type of apparmor confinement.
+ **/
 enum sc_apparmor_mode {
 	// The enforcement mode was not recognized.
 	SC_AA_INVALID = -1,
@@ -34,6 +34,9 @@ enum sc_apparmor_mode {
 	SC_AA_COMPLAIN,
 };
 
+/**
+ * Data required to manage apparmor wrapper.
+ **/
 struct sc_apparmor {
 	// The mode of enforcement. In addition to the two apparmor defined modes
 	// can be also SC_AA_INVALID (unknown mode reported by apparmor) and

--- a/src/apparmor-support.h
+++ b/src/apparmor-support.h
@@ -86,6 +86,6 @@ sc_maybe_aa_change_onexec(struct sc_apparmor *apparmor, const char *profile);
  **/
 void
 sc_maybe_aa_change_hat(struct sc_apparmor *apparmor,
-		       const char *subprofile, unsigned long magic_token)
+		       const char *subprofile, unsigned long magic_token);
 
 #endif

--- a/src/apparmor-support.h
+++ b/src/apparmor-support.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_APPARMOR_SUPPORT_H
+#define SNAP_CONFINE_APPARMOR_SUPPORT_H
+
+/**
+ * Data required to manage apparmor wrapper. 
+ */
+struct sc_apparmor;
+
+/**
+ * Initialize apparmor support.
+ *
+ * This operation should be done even when apparmor support is disabled at
+ * compile time. Internally the supplied structure is initialized based on the
+ * information returned from aa_getcon(2) or if apparmor is disabled at compile
+ * time, with built-in constants.
+ *
+ * The main action performed here is to check if snap-confine is currently
+ * confined, this information is used later in sc_maybe_change_apparmor_hat()
+ *
+ * As with many functions in the snap-confine tree, all errors result in
+ * process termination.
+ **/
+void sc_init_apparmor_support(struct sc_apparmor *apparmor);
+
+/**
+ * Maybe call aa_change_onexec(2)
+ *
+ * This function does nothing when apparmor support is not enabled at compile
+ * time. If apparmor is enabled then profile change request is attempted.
+ *
+ * As with many functions in the snap-confine tree, all errors result in
+ * process termination. As an exception, when SNAPPY_LAUNCHER_INSIDE_TESTS
+ * environment variable is set then the process is not terminated.
+ **/
+void
+sc_maybe_aa_chagne_onexec(struct sc_apparmor *apparmor, const char *profile);
+
+/**
+ * Maybe call aa_change_hat(2)
+ *
+ * This function does nothing when apparmor support is not enabled at compile
+ * time. If apparmor is enabled then hat change is attempted.
+ *
+ * As with many functions in the snap-confine tree, all errors result in
+ * process termination.
+ **/
+void
+sc_maybe_change_apparmor_hat(struct sc_apparmor *apparmor,
+			     const char *subprofile, unsigned long magic_token);
+
+#endif


### PR DESCRIPTION
This patch adds a new set of files, mimicking the xxx-support pattern
used for other changes, that so some extent abstracts the use of
apparmor in snap-confine.

Even when snap-confine is not compiled with apparmor support the same
APIs are available and gracefully degrade to no-ops.

As a small extension, snap confine can now know if it is confined (e.g.
a development version running in a random directory is not confined) and
will no longer crash when changing hats via aa_change_hat().

The patch doesn't yet change any of the tree to use the new functions.
This will be done in the next commit.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>