### PR TITLE
Add error support code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ src/snap-confine-unit-tests
 src/snap-confine.apparmor
 src/decode-mount-opts
 *~
+.*.swp
 *.o
 
 # test-driver

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -63,7 +63,9 @@ snap_confine_SOURCES = \
 	ns-support.c \
 	ns-support.h \
 	apparmor-support.c \
-	apparmor-support.h
+	apparmor-support.h \
+	error.c \
+	error.h
 
 snap_confine_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_confine_LDFLAGS = $(AM_LDFLAGS)
@@ -106,7 +108,8 @@ snap_confine_unit_tests_SOURCES = \
 	ns-support-test.c \
 	apparmor-support.c \
 	apparmor-support.h \
-	mount-opt-test.c
+	mount-opt-test.c \
+	error-test.c
 snap_confine_unit_tests_CFLAGS = $(snap_confine_CFLAGS) $(GLIB_CFLAGS)
 snap_confine_unit_tests_LDADD = $(snap_confine_LDADD) $(GLIB_LIBS)
 snap_confine_unit_tests_LDFLAGS = $(snap_confine_LDFLAGS)

--- a/src/error-test.c
+++ b/src/error-test.c
@@ -68,7 +68,10 @@ static void test_sc_error_domain__NULL()
 {
 	// Check that sc_error_domain() dies if called with NULL error.
 	if (g_test_subprocess()) {
-		sc_error_domain(NULL);
+		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
+		struct sc_error *err = NULL;
+		const char *domain = sc_error_domain(err);
+		(void)(domain);
 		g_test_message("expected not to reach this place");
 		g_test_fail();
 		return;
@@ -83,7 +86,10 @@ static void test_sc_error_code__NULL()
 {
 	// Check that sc_error_code() dies if called with NULL error.
 	if (g_test_subprocess()) {
-		sc_error_code(NULL);
+		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
+		struct sc_error *err = NULL;
+		int code = sc_error_code(err);
+		(void)(code);
 		g_test_message("expected not to reach this place");
 		g_test_fail();
 		return;
@@ -97,7 +103,10 @@ static void test_sc_error_msg__NULL()
 {
 	// Check that sc_error_msg() dies if called with NULL error.
 	if (g_test_subprocess()) {
-		sc_error_msg(NULL);
+		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
+		struct sc_error *err = NULL;
+		const char *msg = sc_error_msg(err);
+		(void)(msg);
 		g_test_message("expected not to reach this place");
 		g_test_fail();
 		return;
@@ -171,11 +180,13 @@ static void test_sc_error_forward__something_nowhere()
 {
 	// Check that forwarding a real error nowhere calls die()
 	if (g_test_subprocess()) {
+		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
+		struct sc_error **err_ptr = NULL;
 		struct sc_error *err =
 		    sc_error_init("domain", 42, "just testing");
 		g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
 		g_assert_nonnull(err);
-		sc_error_forward(NULL, err);
+		sc_error_forward(err_ptr, err);
 		g_test_message("expected not to reach this place");
 		g_test_fail();
 		return;
@@ -201,9 +212,12 @@ static void test_sc_error_match__typical()
 
 static void test_sc_error_match__NULL_domain()
 {
+	// Using a NULL domain is a fatal bug.
 	if (g_test_subprocess()) {
-		// Using a NULL domain is a fatal bug.
-		g_assert_false(sc_error_match(NULL, NULL, 42));
+		// NOTE: the code below fools gcc 5.4 but your mileage may vary.
+		struct sc_error *err = NULL;
+		const char *domain = NULL;
+		g_assert_false(sc_error_match(err, domain, 42));
 		g_test_message("expected not to reach this place");
 		g_test_fail();
 		return;

--- a/src/error-test.c
+++ b/src/error-test.c
@@ -117,24 +117,24 @@ static void test_sc_error_msg__NULL()
 	    ("cannot obtain error message from NULL error\n");
 }
 
-static void test_sc_error_die__NULL()
+static void test_sc_die_on_error__NULL()
 {
-	// Check that sc_error_die() does nothing if called with NULL error.
+	// Check that sc_die_on_error() does nothing if called with NULL error.
 	if (g_test_subprocess()) {
-		sc_error_die(NULL);
+		sc_die_on_error(NULL);
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
 	g_test_trap_assert_passed();
 }
 
-static void test_sc_error_die__regular()
+static void test_sc_die_on_error__regular()
 {
-	// Check that sc_error_die() dies if called with an error.
+	// Check that sc_die_on_error() dies if called with an error.
 	if (g_test_subprocess()) {
 		struct sc_error *err =
 		    sc_error_init("domain", 42, "just testing");
-		sc_error_die(err);
+		sc_die_on_error(err);
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
@@ -142,13 +142,13 @@ static void test_sc_error_die__regular()
 	g_test_trap_assert_stderr("just testing\n");
 }
 
-static void test_sc_error_die__errno()
+static void test_sc_die_on_error__errno()
 {
-	// Check that sc_error_die() dies if called with an errno-based error.
+	// Check that sc_die_on_error() dies if called with an errno-based error.
 	if (g_test_subprocess()) {
 		struct sc_error *err =
 		    sc_error_init_from_errno(ENOENT, "just testing");
-		sc_error_die(err);
+		sc_die_on_error(err);
 		return;
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
@@ -237,10 +237,12 @@ static void __attribute__ ((constructor)) init()
 			test_sc_error_domain__NULL);
 	g_test_add_func("/error/sc_error_code/NULL", test_sc_error_code__NULL);
 	g_test_add_func("/error/sc_error_msg/NULL", test_sc_error_msg__NULL);
-	g_test_add_func("/error/sc_error_die/NULL", test_sc_error_die__NULL);
-	g_test_add_func("/error/sc_error_die/regular",
-			test_sc_error_die__regular);
-	g_test_add_func("/error/sc_error_die/errno", test_sc_error_die__errno);
+	g_test_add_func("/error/sc_die_on_error/NULL",
+			test_sc_die_on_error__NULL);
+	g_test_add_func("/error/sc_die_on_error/regular",
+			test_sc_die_on_error__regular);
+	g_test_add_func("/error/sc_die_on_error/errno",
+			test_sc_die_on_error__errno);
 	g_test_add_func("/error/sc_error_formward/nothing",
 			test_sc_error_forward__nothing);
 	g_test_add_func("/error/sc_error_formward/something_somewhere",

--- a/src/error-test.c
+++ b/src/error-test.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "error.h"
+#include "error.c"
+
+#include <errno.h>
+#include <glib.h>
+
+static void test_sc_error_init()
+{
+	struct sc_error *err;
+	// Create an error
+	err = sc_error_init("domain", 42, "printer is on %s", "fire");
+	g_assert_nonnull(err);
+	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+
+	// Inspect the exposed attributes
+	g_assert_cmpstr(sc_error_domain(err), ==, "domain");
+	g_assert_cmpint(sc_error_code(err), ==, 42);
+	g_assert_cmpstr(sc_error_msg(err), ==, "printer is on fire");
+}
+
+static void test_sc_error_init_from_errno()
+{
+	struct sc_error *err;
+	// Create an error
+	err = sc_error_init_from_errno(ENOENT, "printer is on %s", "fire");
+	g_assert_nonnull(err);
+	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+
+	// Inspect the exposed attributes
+	g_assert_cmpstr(sc_error_domain(err), ==, SC_ERRNO_DOMAIN);
+	g_assert_cmpint(sc_error_code(err), ==, ENOENT);
+	g_assert_cmpstr(sc_error_msg(err), ==, "printer is on fire");
+}
+
+static void test_sc_error_cleanup()
+{
+	// Check that sc_error_cleanup() is safe to use.
+
+	// Cleanup is safe on NULL errors.
+	struct sc_error *err = NULL;
+	sc_cleanup_error(&err);
+
+	// Cleanup is safe on non-NULL errors.
+	err = sc_error_init("domain", 123, "msg");
+	g_assert_nonnull(err);
+	sc_cleanup_error(&err);
+	g_assert_null(err);
+}
+
+static void test_sc_error_domain__NULL()
+{
+	// Check that sc_error_domain() dies if called with NULL error.
+	if (g_test_subprocess()) {
+		sc_error_domain(NULL);
+		g_test_message("expected not to reach this place");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("cannot obtain error domain from NULL error\n");
+}
+
+static void test_sc_error_code__NULL()
+{
+	// Check that sc_error_code() dies if called with NULL error.
+	if (g_test_subprocess()) {
+		sc_error_code(NULL);
+		g_test_message("expected not to reach this place");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("cannot obtain error code from NULL error\n");
+}
+
+static void test_sc_error_msg__NULL()
+{
+	// Check that sc_error_msg() dies if called with NULL error.
+	if (g_test_subprocess()) {
+		sc_error_msg(NULL);
+		g_test_message("expected not to reach this place");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("cannot obtain error message from NULL error\n");
+}
+
+static void test_sc_error_die__NULL()
+{
+	// Check that sc_error_die() does nothing if called with NULL error.
+	if (g_test_subprocess()) {
+		sc_error_die(NULL);
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_passed();
+}
+
+static void test_sc_error_die__regular()
+{
+	// Check that sc_error_die() dies if called with an error.
+	if (g_test_subprocess()) {
+		struct sc_error *err =
+		    sc_error_init("domain", 42, "just testing");
+		sc_error_die(err);
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("just testing\n");
+}
+
+static void test_sc_error_die__errno()
+{
+	// Check that sc_error_die() dies if called with an errno-based error.
+	if (g_test_subprocess()) {
+		struct sc_error *err =
+		    sc_error_init_from_errno(ENOENT, "just testing");
+		sc_error_die(err);
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("just testing: No such file or directory\n");
+}
+
+static void test_sc_error_forward__nothing()
+{
+	// Check that forwarding NULL does exactly that.
+	struct sc_error *recepient = (void *)0xDEADBEEF;
+	struct sc_error *err = NULL;
+	sc_error_forward(&recepient, err);
+	g_assert_null(recepient);
+}
+
+static void test_sc_error_forward__something_somewhere()
+{
+	// Check that forwarding a real error works OK.
+	struct sc_error *recepient = NULL;
+	struct sc_error *err = sc_error_init("domain", 42, "just testing");
+	g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+	g_assert_nonnull(err);
+	sc_error_forward(&recepient, err);
+	g_assert_nonnull(recepient);
+}
+
+static void test_sc_error_forward__something_nowhere()
+{
+	// Check that forwarding a real error nowhere calls die()
+	if (g_test_subprocess()) {
+		struct sc_error *err =
+		    sc_error_init("domain", 42, "just testing");
+		g_test_queue_destroy((GDestroyNotify) sc_error_free, err);
+		g_assert_nonnull(err);
+		sc_error_forward(NULL, err);
+		g_test_message("expected not to reach this place");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("just testing\n");
+}
+
+static void __attribute__ ((constructor)) init()
+{
+	g_test_add_func("/error/sc_error_init", test_sc_error_init);
+	g_test_add_func("/error/sc_error_init_from_errno",
+			test_sc_error_init_from_errno);
+	g_test_add_func("/error/sc_error_cleanup", test_sc_error_cleanup);
+	g_test_add_func("/error/sc_error_domain/NULL",
+			test_sc_error_domain__NULL);
+	g_test_add_func("/error/sc_error_code/NULL", test_sc_error_code__NULL);
+	g_test_add_func("/error/sc_error_msg/NULL", test_sc_error_msg__NULL);
+	g_test_add_func("/error/sc_error_die/NULL", test_sc_error_die__NULL);
+	g_test_add_func("/error/sc_error_die/regular",
+			test_sc_error_die__regular);
+	g_test_add_func("/error/sc_error_die/errno", test_sc_error_die__errno);
+	g_test_add_func("/error/sc_error_formward/nothing",
+			test_sc_error_forward__nothing);
+	g_test_add_func("/error/sc_error_formward/something_somewhere",
+			test_sc_error_forward__something_somewhere);
+	g_test_add_func("/error/sc_error_formward/something_nowhere",
+			test_sc_error_forward__something_nowhere);
+}

--- a/src/error.c
+++ b/src/error.c
@@ -100,6 +100,7 @@ void sc_error_free(struct sc_error *err)
 {
 	if (err != NULL) {
 		free(err->msg);
+		err->msg = NULL;
 		free(err);
 	}
 }

--- a/src/error.c
+++ b/src/error.c
@@ -110,7 +110,7 @@ void sc_cleanup_error(struct sc_error **ptr)
 	*ptr = NULL;
 }
 
-void sc_error_die(struct sc_error *error)
+void sc_die_on_error(struct sc_error *error)
 {
 	if (error != NULL) {
 		if (strcmp(sc_error_domain(error), SC_ERRNO_DOMAIN) == 0) {
@@ -129,7 +129,7 @@ void sc_error_forward(struct sc_error **recepient, struct sc_error *error)
 	if (recepient != NULL) {
 		*recepient = error;
 	} else {
-		sc_error_die(error);
+		sc_die_on_error(error);
 	}
 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -142,5 +142,6 @@ bool sc_error_match(struct sc_error *error, const char *domain, int code)
 	if (error == NULL) {
 		return false;
 	}
-	return strcmp(error->domain, domain) == 0 && error->code == code;
+	return strcmp(sc_error_domain(error), domain) == 0
+	    && sc_error_code(error) == code;
 }

--- a/src/error.c
+++ b/src/error.c
@@ -124,10 +124,10 @@ void sc_die_on_error(struct sc_error *error)
 	}
 }
 
-void sc_error_forward(struct sc_error **recepient, struct sc_error *error)
+void sc_error_forward(struct sc_error **recipient, struct sc_error *error)
 {
-	if (recepient != NULL) {
-		*recepient = error;
+	if (recipient != NULL) {
+		*recipient = error;
 	} else {
 		sc_die_on_error(error);
 	}

--- a/src/error.c
+++ b/src/error.c
@@ -132,3 +132,14 @@ void sc_error_forward(struct sc_error **recepient, struct sc_error *error)
 		sc_error_die(error);
 	}
 }
+
+bool sc_error_match(struct sc_error *error, const char *domain, int code)
+{
+	if (domain == NULL) {
+		die("cannot match error to a NULL domain");
+	}
+	if (error == NULL) {
+		return false;
+	}
+	return strcmp(error->domain, domain) == 0 && error->code == code;
+}

--- a/src/error.c
+++ b/src/error.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "error.h"
+
+// To get vasprintf
+#define _GNU_SOURCE
+
+#include "utils.h"
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+struct sc_error {
+	// Error domain defines a scope for particular error codes.
+	const char *domain;
+	// Code differentiates particular errors for the programmer.
+	// The code may be zero if the particular meaning is not relevant.
+	int code;
+	// Message carries a formatted description of the problem.
+	char *msg;
+};
+
+static struct sc_error *sc_error_initv(const char *domain, int code,
+				       const char *msgfmt, va_list ap)
+{
+	struct sc_error *err = calloc(1, sizeof *err);
+	if (err == NULL) {
+		die("cannot allocate memory for error object");
+	}
+	err->domain = domain;
+	err->code = code;
+	if (vasprintf(&err->msg, msgfmt, ap) == -1) {
+		die("cannot format error message");
+	}
+	return err;
+}
+
+struct sc_error *sc_error_init(const char *domain, int code, const char *msgfmt,
+			       ...)
+{
+	va_list ap;
+	va_start(ap, msgfmt);
+	struct sc_error *err = sc_error_initv(domain, code, msgfmt, ap);
+	va_end(ap);
+	return err;
+}
+
+struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
+					  ...)
+{
+	va_list ap;
+	va_start(ap, msgfmt);
+	struct sc_error *err =
+	    sc_error_initv(SC_ERRNO_DOMAIN, errno_copy, msgfmt, ap);
+	va_end(ap);
+	return err;
+}
+
+const char *sc_error_domain(struct sc_error *err)
+{
+	if (err == NULL) {
+		die("cannot obtain error domain from NULL error");
+	}
+	return err->domain;
+}
+
+int sc_error_code(struct sc_error *err)
+{
+	if (err == NULL) {
+		die("cannot obtain error code from NULL error");
+	}
+	return err->code;
+}
+
+const char *sc_error_msg(struct sc_error *err)
+{
+	if (err == NULL) {
+		die("cannot obtain error message from NULL error");
+	}
+	return err->msg;
+}
+
+void sc_error_free(struct sc_error *err)
+{
+	if (err != NULL) {
+		free(err->msg);
+		free(err);
+	}
+}
+
+void sc_cleanup_error(struct sc_error **ptr)
+{
+	sc_error_free(*ptr);
+	*ptr = NULL;
+}
+
+void sc_error_die(struct sc_error *error)
+{
+	if (error != NULL) {
+		if (strcmp(sc_error_domain(error), SC_ERRNO_DOMAIN) == 0) {
+			// Set errno just before the call to die() as it is used internally
+			errno = sc_error_code(error);
+			die("%s", sc_error_msg(error));
+		} else {
+			errno = 0;
+			die("%s", sc_error_msg(error));
+		}
+	}
+}
+
+void sc_error_forward(struct sc_error **recepient, struct sc_error *error)
+{
+	if (recepient != NULL) {
+		*recepient = error;
+	} else {
+		sc_error_die(error);
+	}
+}

--- a/src/error.h
+++ b/src/error.h
@@ -68,8 +68,8 @@ struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
 /**
  * Get the error domain out of an error object.
  *
- * The error domain acts as a namespace for error codes. The return value must
- * not be released in any way.
+ * The error domain acts as a namespace for error codes.
+ * No change of ownership takes place.
  **/
 __attribute__ ((warn_unused_result, nonnull, returns_nonnull))
 const char *sc_error_domain(struct sc_error *err);
@@ -91,6 +91,7 @@ int sc_error_code(struct sc_error *err);
  * Get the error message out of an error object.
  *
  * The error message is bound to the life-cycle of the error object.
+ * No change of ownership takes place.
  **/
 __attribute__ ((warn_unused_result, nonnull, returns_nonnull))
 const char *sc_error_msg(struct sc_error *err);
@@ -128,9 +129,11 @@ void sc_die_on_error(struct sc_error *error);
  * This tries to forward an error to the caller. If this is impossible because
  * the caller did not provide a location for the error to be stored then the
  * sc_die_on_error() is called as a safety measure.
+ *
+ * Change of ownership takes place and the error is now stored in the recipient.
  **/
 __attribute__ ((nonnull(1)))
-void sc_error_forward(struct sc_error **recepient, struct sc_error *error);
+void sc_error_forward(struct sc_error **recipient, struct sc_error *error);
 
 /**
  * Check if a given error matches the specified domain and code.

--- a/src/error.h
+++ b/src/error.h
@@ -49,7 +49,7 @@ struct sc_error;
  *
  * This function calls die() in case of memory allocation failure.
  **/
-__attribute__ ((format(printf, 3, 4)))
+__attribute__ ((warn_unused_result, format(printf, 3, 4), returns_nonnull))
 struct sc_error *sc_error_init(const char *domain, int code, const char *msgfmt,
 			       ...);
 
@@ -61,7 +61,7 @@ struct sc_error *sc_error_init(const char *domain, int code, const char *msgfmt,
  *
  * This function calls die() in case of memory allocation failure.
  **/
-__attribute__ ((format(printf, 2, 3)))
+__attribute__ ((warn_unused_result, format(printf, 2, 3), returns_nonnull))
 struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
 					  ...);
 
@@ -71,6 +71,7 @@ struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
  * The error domain acts as a namespace for error codes. The return value must
  * not be released in any way.
  **/
+__attribute__ ((warn_unused_result, nonnull, returns_nonnull))
 const char *sc_error_domain(struct sc_error *err);
 
 /**
@@ -83,6 +84,7 @@ const char *sc_error_domain(struct sc_error *err);
  * can rely on programmatically. This can be used to return an error message
  * without having to allocate a distinct code for each one.
  **/
+__attribute__ ((warn_unused_result, nonnull))
 int sc_error_code(struct sc_error *err);
 
 /**
@@ -90,6 +92,7 @@ int sc_error_code(struct sc_error *err);
  *
  * The error message is bound to the life-cycle of the error object.
  **/
+__attribute__ ((warn_unused_result, nonnull, returns_nonnull))
 const char *sc_error_msg(struct sc_error *err);
 
 /**
@@ -105,6 +108,7 @@ void sc_error_free(struct sc_error *error);
  * This function is designed to be used with
  * __attribute__((cleanup(sc_cleanup_error))).
  **/
+__attribute__ ((nonnull))
 void sc_cleanup_error(struct sc_error **ptr);
 
 /**
@@ -125,6 +129,7 @@ void sc_error_die(struct sc_error *error);
  * the caller did not provide a location for the error to be stored then the
  * sc_error_die() is called as a safety measure.
  **/
+__attribute__ ((nonnull(1)))
 void sc_error_forward(struct sc_error **recepient, struct sc_error *error);
 
 /**
@@ -133,6 +138,7 @@ void sc_error_forward(struct sc_error **recepient, struct sc_error *error);
  * It is okay to match a NULL error, the function simply returns false in that
  * case. The domain cannot be NULL though.
  **/
+__attribute__ ((warn_unused_result, nonnull(2)))
 bool sc_error_match(struct sc_error *error, const char *domain, int code);
 
 #endif

--- a/src/error.h
+++ b/src/error.h
@@ -132,7 +132,8 @@ void sc_die_on_error(struct sc_error *error);
  *
  * Change of ownership takes place and the error is now stored in the recipient.
  **/
-__attribute__ ((nonnull(1)))
+// NOTE: There's no nonnull(1) attribute as the recipient *can* be NULL. With
+// the attribute in place GCC optimizes some things out and tests fail.
 void sc_error_forward(struct sc_error **recipient, struct sc_error *error);
 
 /**

--- a/src/error.h
+++ b/src/error.h
@@ -120,14 +120,14 @@ void sc_cleanup_error(struct sc_error **ptr);
  * The error message is derived from the data in the error, using the special
  * errno domain to provide additional information if that is available.
  **/
-void sc_error_die(struct sc_error *error);
+void sc_die_on_error(struct sc_error *error);
 
 /**
  * Forward an error to the caller.
  *
  * This tries to forward an error to the caller. If this is impossible because
  * the caller did not provide a location for the error to be stored then the
- * sc_error_die() is called as a safety measure.
+ * sc_die_on_error() is called as a safety measure.
  **/
 __attribute__ ((nonnull(1)))
 void sc_error_forward(struct sc_error **recepient, struct sc_error *error);

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_ERROR_H
+#define SNAP_CONFINE_ERROR_H
+
+/**
+ * This module defines APIs for simple error management.
+ *
+ * Errors are allocated objects that can be returned and passed around from
+ * functions.  Errors carry a formatted message and optionally a scoped error
+ * code. The code is coped with a string "domain" that simply acts as a
+ * namespace for various interacting modules.
+ **/
+
+/**
+ * Opaque error structure.
+ **/
+struct sc_error;
+
+/**
+ * Error domain for errors related to system errno.
+ **/
+#define SC_ERRNO_DOMAIN "errno"
+
+/**
+ * Initialize a new error object.
+ *
+ * The domain is a cookie-like string that allows the caller to distinguish
+ * between "namespaces" of error codes. It should be a static string that is
+ * provided by the caller. Both the domain and the error code can be retrieved
+ * later.
+ *
+ * This function calls die() in case of memory allocation failure.
+ **/
+__attribute__ ((format(printf, 3, 4)))
+struct sc_error *sc_error_init(const char *domain, int code, const char *msgfmt,
+			       ...);
+
+/**
+ * Initialize an errno-based error.
+ *
+ * The error carries a copy of errno and a custom error message as designed by
+ * the caller. See sc_error_init() for a more complete description.
+ *
+ * This function calls die() in case of memory allocation failure.
+ **/
+__attribute__ ((format(printf, 2, 3)))
+struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
+					  ...);
+
+/**
+ * Get the error domain out of an error object.
+ *
+ * The error domain acts as a namespace for error codes. The return value must
+ * not be released in any way.
+ **/
+const char *sc_error_domain(struct sc_error *err);
+
+/**
+ * Get the error code out of an error object.
+ *
+ * The error code is scoped by the error domain.
+ *
+ * An error code of zero is special-cased to indicate that no particular error
+ * code is reserved for this error and it's not something that the programmer
+ * can rely on programmatically. This can be used to return an error message
+ * without having to allocate a distinct code for each one.
+ **/
+int sc_error_code(struct sc_error *err);
+
+/**
+ * Get the error message out of an error object.
+ *
+ * The error message is bound to the life-cycle of the error object.
+ **/
+const char *sc_error_msg(struct sc_error *err);
+
+/**
+ * Free an error object.
+ *
+ * The error object can be NULL.
+ **/
+void sc_error_free(struct sc_error *error);
+
+/**
+ * Cleanup an error with sc_error_free()
+ *
+ * This function is designed to be used with
+ * __attribute__((cleanup(sc_cleanup_error))).
+ **/
+void sc_cleanup_error(struct sc_error **ptr);
+
+/**
+ *
+ * Die if there's an error.
+ *
+ * This function is a correct way to die() if the passed error is not NULL.
+ *
+ * The error message is derived from the data in the error, using the special
+ * errno domain to provide additional information if that is available.
+ **/
+void sc_error_die(struct sc_error *error);
+
+/**
+ * Forward an error to the caller.
+ *
+ * This tries to forward an error to the caller. If this is impossible because
+ * the caller did not provide a location for the error to be stored then the
+ * sc_error_die() is called as a safety measure.
+ **/
+void sc_error_forward(struct sc_error **recepient, struct sc_error *error);
+
+#endif

--- a/src/error.h
+++ b/src/error.h
@@ -18,6 +18,8 @@
 #ifndef SNAP_CONFINE_ERROR_H
 #define SNAP_CONFINE_ERROR_H
 
+#include <stdbool.h>
+
 /**
  * This module defines APIs for simple error management.
  *
@@ -124,5 +126,13 @@ void sc_error_die(struct sc_error *error);
  * sc_error_die() is called as a safety measure.
  **/
 void sc_error_forward(struct sc_error **recepient, struct sc_error *error);
+
+/**
+ * Check if a given error matches the specified domain and code.
+ *
+ * It is okay to match a NULL error, the function simply returns false in that
+ * case. The domain cannot be NULL though.
+ **/
+bool sc_error_match(struct sc_error *error, const char *domain, int code);
 
 #endif


### PR DESCRIPTION
This patch adds die()-like APIs that can carry error information around
the control flow. They are meant to provide richer error information  in
cases where the error is not fatal and needs to be returned to the
caller. The APIs are 100% tested and also integrate with die() where
appropriate().

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>