### PR TITLE
Add module for parsing command line arguments.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -65,7 +65,9 @@ snap_confine_SOURCES = \
 	apparmor-support.c \
 	apparmor-support.h \
 	error.c \
-	error.h
+	error.h \
+	snap-confine-args.c \
+	snap-confine-args.h
 
 snap_confine_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_confine_LDFLAGS = $(AM_LDFLAGS)
@@ -109,7 +111,8 @@ snap_confine_unit_tests_SOURCES = \
 	apparmor-support.c \
 	apparmor-support.h \
 	mount-opt-test.c \
-	error-test.c
+	error-test.c \
+	snap-confine-args-test.c
 snap_confine_unit_tests_CFLAGS = $(snap_confine_CFLAGS) $(GLIB_CFLAGS)
 snap_confine_unit_tests_LDADD = $(snap_confine_LDADD) $(GLIB_LIBS)
 snap_confine_unit_tests_LDFLAGS = $(snap_confine_LDFLAGS)

--- a/src/snap-confine-args-test.c
+++ b/src/snap-confine-args-test.c
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "snap-confine-args.h"
+#include "snap-confine-args.c"
+
+#include <stdarg.h>
+
+#include <glib.h>
+
+/**
+ * Create an argc + argv pair out of a NULL terminated argument list.
+ **/
+static void
+    __attribute__ ((sentinel)) test_argc_argv(int *argcp, char ***argvp, ...)
+{
+	int argc = 0;
+	char **argv = NULL;
+	g_test_queue_free(argv);
+
+	va_list ap;
+	va_start(ap, argvp);
+	const char *arg;
+	do {
+		arg = va_arg(ap, const char *);
+		// XXX: yeah, wrong way but the worse that can happen is for test to fail
+		argv = realloc(argv, sizeof(const char **) * (argc + 1));
+		g_assert_nonnull(argv);
+		if (arg != NULL) {
+			char *arg_copy = strdup(arg);
+			g_test_queue_free(arg_copy);
+			argv[argc] = arg_copy;
+			argc += 1;
+		} else {
+			argv[argc] = NULL;
+		}
+	} while (arg != NULL);
+	va_end(ap);
+
+	*argcp = argc;
+	*argvp = argv;
+}
+
+static void test_test_argc_argv()
+{
+	// Check that test_argc_argv() correctly stores data
+	int argc;
+	char **argv;
+
+	test_argc_argv(&argc, &argv, NULL);
+	g_assert_cmpint(argc, ==, 0);
+	g_assert_null(argv[0]);
+
+	test_argc_argv(&argc, &argv, "zero", "one", "two", NULL);
+	g_assert_cmpint(argc, ==, 3);
+	g_assert_cmpstr(argv[0], ==, "zero");
+	g_assert_cmpstr(argv[1], ==, "one");
+	g_assert_cmpstr(argv[2], ==, "two");
+	g_assert_null(argv[3]);
+}
+
+static void test_sc_nonfatal_parse_args__typical()
+{
+	// Test that typical invocation of snap-confine is parsed correctly.
+	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+
+	int argc;
+	char **argv;
+	test_argc_argv(&argc, &argv,
+		       "/usr/lib/snapd/snap-confine", "snap.SNAP_NAME.APP_NAME",
+		       "/usr/lib/snapd/snap-exec", "--option", "arg", NULL);
+
+	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+	g_assert_null(err);
+	g_assert_nonnull(args);
+
+	// Check supported switches and arguments
+	g_assert_cmpstr(sc_args_security_tag(args), ==,
+			"snap.SNAP_NAME.APP_NAME");
+	g_assert_cmpstr(sc_args_executable(args), ==,
+			"/usr/lib/snapd/snap-exec");
+	g_assert_cmpint(sc_args_is_version_query(args), ==, false);
+	g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
+
+	// Check remaining arguments
+	g_assert_cmpint(argc, ==, 3);
+	g_assert_cmpstr(argv[0], ==, "/usr/lib/snapd/snap-confine");
+	g_assert_cmpstr(argv[1], ==, "--option");
+	g_assert_cmpstr(argv[2], ==, "arg");
+	g_assert_null(argv[3]);
+}
+
+static void test_sc_cleanup_args()
+{
+	// Check that NULL argument parser can be cleaned up
+	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_args *args = NULL;
+	sc_cleanup_args(&args);
+
+	// Check that a non-NULL argument parser can be cleaned up
+	int argc;
+	char **argv;
+	test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine",
+		       "snap.SNAP_NAME.APP_NAME", "/usr/lib/snapd/snap-exec",
+		       NULL);
+	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+	g_assert_null(err);
+	g_assert_nonnull(args);
+
+	sc_cleanup_args(&args);
+	g_assert_null(args);
+}
+
+static void test_sc_nonfatal_parse_args__typical_classic()
+{
+	// Test that typical invocation of snap-confine is parsed correctly.
+	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+
+	int argc;
+	char **argv;
+	test_argc_argv(&argc, &argv,
+		       "/usr/lib/snapd/snap-confine", "--classic",
+		       "snap.SNAP_NAME.APP_NAME", "/usr/lib/snapd/snap-exec",
+		       "--option", "arg", NULL);
+
+	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+	g_assert_null(err);
+	g_assert_nonnull(args);
+
+	// Check supported switches and arguments
+	g_assert_cmpstr(sc_args_security_tag(args), ==,
+			"snap.SNAP_NAME.APP_NAME");
+	g_assert_cmpstr(sc_args_executable(args), ==,
+			"/usr/lib/snapd/snap-exec");
+	g_assert_cmpint(sc_args_is_version_query(args), ==, false);
+	g_assert_cmpint(sc_args_is_classic_confinement(args), ==, true);
+
+	// Check remaining arguments
+	g_assert_cmpint(argc, ==, 3);
+	g_assert_cmpstr(argv[0], ==, "/usr/lib/snapd/snap-confine");
+	g_assert_cmpstr(argv[1], ==, "--option");
+	g_assert_cmpstr(argv[2], ==, "arg");
+	g_assert_null(argv[3]);
+}
+
+static void test_sc_nonfatal_parse_args__ubuntu_core_launcher()
+{
+	// Test that typical legacy invocation of snap-confine via the
+	// ubuntu-core-launcher symlink, with duplicated security tag, is parsed
+	// correctly.
+	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+
+	int argc;
+	char **argv;
+	test_argc_argv(&argc, &argv,
+		       "/usr/bin/ubuntu-core-launcher",
+		       "snap.SNAP_NAME.APP_NAME", "snap.SNAP_NAME.APP_NAME",
+		       "/usr/lib/snapd/snap-exec", "--option", "arg", NULL);
+
+	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+	g_assert_null(err);
+	g_assert_nonnull(args);
+
+	// Check supported switches and arguments
+	g_assert_cmpstr(sc_args_security_tag(args), ==,
+			"snap.SNAP_NAME.APP_NAME");
+	g_assert_cmpstr(sc_args_executable(args), ==,
+			"/usr/lib/snapd/snap-exec");
+	g_assert_cmpint(sc_args_is_version_query(args), ==, false);
+	g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
+
+	// Check remaining arguments
+	g_assert_cmpint(argc, ==, 3);
+	g_assert_cmpstr(argv[0], ==, "/usr/bin/ubuntu-core-launcher");
+	g_assert_cmpstr(argv[1], ==, "--option");
+	g_assert_cmpstr(argv[2], ==, "arg");
+	g_assert_null(argv[3]);
+}
+
+static void test_sc_nonfatal_parse_args__version()
+{
+	// Test that snap-confine --version is detected.
+	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+
+	int argc;
+	char **argv;
+	test_argc_argv(&argc, &argv,
+		       "/usr/lib/snapd/snap-confine", "--version", "ignored",
+		       "garbage", NULL);
+
+	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+	g_assert_null(err);
+	g_assert_nonnull(args);
+
+	// Check supported switches and arguments
+	g_assert_null(sc_args_security_tag(args));
+	g_assert_null(sc_args_executable(args));
+	g_assert_cmpint(sc_args_is_version_query(args), ==, true);
+	g_assert_cmpint(sc_args_is_classic_confinement(args), ==, false);
+
+	// Check remaining arguments
+	g_assert_cmpint(argc, ==, 3);
+	g_assert_cmpstr(argv[0], ==, "/usr/lib/snapd/snap-confine");
+	g_assert_cmpstr(argv[1], ==, "ignored");
+	g_assert_cmpstr(argv[2], ==, "garbage");
+	g_assert_null(argv[3]);
+}
+
+static void test_sc_nonfatal_parse_args__nothing_to_parse()
+{
+	// Check that calling without any arguments is reported as error.
+	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+
+	int argc;
+	char **argv;
+	test_argc_argv(&argc, &argv, NULL);
+
+	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+	g_assert_nonnull(err);
+	g_assert_null(args);
+
+	// Check the error that we've got
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"cannot parse arguments, argc is zero");
+}
+
+static void test_sc_nonfatal_parse_args__no_security_tag()
+{
+	// Check that lack of security tag is reported as error.
+	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+
+	int argc;
+	char **argv;
+	test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine", NULL);
+
+	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+	g_assert_nonnull(err);
+	g_assert_null(args);
+
+	// Check the error that we've got
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"application or hook security tag was not provided");
+	g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
+}
+
+static void test_sc_nonfatal_parse_args__no_executable()
+{
+	// Check that lack of security tag is reported as error.
+	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+
+	int argc;
+	char **argv;
+	test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine",
+		       "snap.SNAP_NAME.APP_NAME", NULL);
+
+	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+	g_assert_nonnull(err);
+	g_assert_null(args);
+
+	// Check the error that we've got
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"executable name was not provided");
+	g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
+}
+
+static void test_sc_nonfatal_parse_args__unknown_option()
+{
+	// Check that unrecognized option switch is reported as error.
+	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+
+	int argc;
+	char **argv;
+	test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine",
+		       "--frozbonicator", NULL);
+
+	args = sc_nonfatal_parse_args(&argc, &argv, &err);
+	g_assert_nonnull(err);
+	g_assert_null(args);
+
+	// Check the error that we've got
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"unrecognized command line option: --frozbonicator");
+	g_assert_true(sc_error_match(err, SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE));
+}
+
+static void test_sc_nonfatal_parse_args__forwards_error()
+{
+	// Check that sc_nonfatal_parse_args() forwards errors.
+	if (g_test_subprocess()) {
+		int argc;
+		char **argv;
+		test_argc_argv(&argc, &argv, "/usr/lib/snapd/snap-confine",
+			       "--frozbonicator", NULL);
+
+		// Call sc_nonfatal_parse_args() without an error handle
+		struct sc_args *args
+		    __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+		args = sc_nonfatal_parse_args(&argc, &argv, NULL);
+		(void)args;
+
+		g_test_message("expected not to reach this place");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("unrecognized command line option: --frozbonicator\n");
+}
+
+static void __attribute__ ((constructor)) init()
+{
+	g_test_add_func("/args/test_argc_argv", test_test_argc_argv);
+	g_test_add_func("/args/sc_cleanup_args", test_sc_cleanup_args);
+	g_test_add_func("/args/sc_nonfatal_parse_args/typical",
+			test_sc_nonfatal_parse_args__typical);
+	g_test_add_func("/args/sc_nonfatal_parse_args/typical_classic",
+			test_sc_nonfatal_parse_args__typical_classic);
+	g_test_add_func("/args/sc_nonfatal_parse_args/ubuntu_core_launcher",
+			test_sc_nonfatal_parse_args__ubuntu_core_launcher);
+	g_test_add_func("/args/sc_nonfatal_parse_args/version",
+			test_sc_nonfatal_parse_args__version);
+	g_test_add_func("/args/sc_nonfatal_parse_args/nothing_to_parse",
+			test_sc_nonfatal_parse_args__nothing_to_parse);
+	g_test_add_func("/args/sc_nonfatal_parse_args/no_security_tag",
+			test_sc_nonfatal_parse_args__no_security_tag);
+	g_test_add_func("/args/sc_nonfatal_parse_args/no_executable",
+			test_sc_nonfatal_parse_args__no_executable);
+	g_test_add_func("/args/sc_nonfatal_parse_args/unknown_option",
+			test_sc_nonfatal_parse_args__unknown_option);
+	g_test_add_func("/args/sc_nonfatal_parse_args/forwards_error",
+			test_sc_nonfatal_parse_args__forwards_error);
+}

--- a/src/snap-confine-args.c
+++ b/src/snap-confine-args.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "snap-confine-args.h"
+
+#include <string.h>
+
+#include "utils.h"
+
+struct sc_args {
+	// The security tag that the application is intended to run with
+	char *security_tag;
+	// The executable that should be invoked
+	char *executable;
+
+	// Flag indicating that --version was passed on command line.
+	bool is_version_query;
+	// Flag indicating that --classic was passed on command line.
+	bool is_classic_confinement;
+};
+
+struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
+				       struct sc_error **errorp)
+{
+	struct sc_args *args = NULL;
+	struct sc_error *err = NULL;
+
+	if (argcp == NULL || argvp == NULL) {
+		err = sc_error_init(SC_ARGS_DOMAIN, 0,
+				    "cannot parse arguments, argc or argv are NULL");
+		goto out;
+	}
+	// Use local copies of argc and argv.
+	int argc = *argcp;
+	char **argv = *argvp;
+
+	if (argc == 0) {
+		err = sc_error_init(SC_ARGS_DOMAIN, 0,
+				    "cannot parse arguments, argc is zero");
+		goto out;
+	}
+
+	args = calloc(1, sizeof *args);
+	if (args == NULL) {
+		die("cannot allocate memory for command line arguments object");
+	}
+	// Check if we're being called through the ubuntu-core-launcher symlink.
+	// When this happens we want to skip the first positional argument as it is
+	// the security tag repeated (legacy).
+	bool ignore_first_tag = false;
+	char *basename = strrchr(argv[0], '/');
+	if (basename != NULL) {
+		// NOTE: this is safe because we, at most, may move to the NUL byte
+		// that compares to an empty string.
+		basename += 1;
+		if (strcmp(basename, "ubuntu-core-launcher") == 0) {
+			ignore_first_tag = true;
+		}
+	}
+	// Parse arguments that we've got
+	int optind;
+	for (optind = 1; optind < argc; ++optind) {
+		// Look at all the options switches that start with the minus sign ('-')
+		if (argv[optind][0] == '-') {
+			// Handle option switches
+			if (strcmp(argv[optind], "--version") == 0) {
+				args->is_version_query = true;
+				// NOTE: --version short-circuits the parser to finish
+				break;
+			} else if (strcmp(argv[optind], "--classic") == 0) {
+				args->is_classic_confinement = true;
+				continue;
+			} else {
+				// Report unhandled option switches
+				err =
+				    sc_error_init(SC_ARGS_DOMAIN,
+						  SC_ARGS_ERR_USAGE,
+						  "unrecognized command line option: %s",
+						  argv[optind]);
+				goto out;
+			}
+		} else {
+			// Handle positional arguments
+			if (args->security_tag == NULL) {
+				// The first positional argument (that is not an option switch)
+				// becomes the security tag.
+				if (ignore_first_tag) {
+					// Unless we are called as ubuntu-core-launcher, then we
+					// just swallow and ignore that security tag altogether.
+					ignore_first_tag = false;
+					continue;
+				}
+				args->security_tag = strdup(argv[optind]);
+				if (args->security_tag == NULL) {
+					die("cannot allocate memory for security tag");
+				}
+			} else if (args->executable == NULL) {
+				// The second positional argument becomes the executable name.
+				args->executable = strdup(argv[optind]);
+				if (args->executable == NULL) {
+					die("cannot allocate memory for executable name");
+				}
+				// No more positional arguments are required.
+				// Stop the parsing process.
+				break;
+			}
+		}
+	}
+
+	if (args->is_version_query == false) {
+		// Ensure that we have the security tag
+		if (args->security_tag == NULL) {
+			err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
+					    "application or hook security tag was not provided");
+			goto out;
+		}
+		// Ensure that we have the executable name
+		if (args->executable == NULL) {
+			err = sc_error_init(SC_ARGS_DOMAIN, SC_ARGS_ERR_USAGE,
+					    "executable name was not provided");
+			goto out;
+		}
+	}
+	// "shift" the argument vector left, except for argv[0], to "consume" the
+	// arguments that were scanned / parsed correctly.
+	int i;
+	for (i = 1; optind + i < argc; ++i) {
+		argv[i] = argv[optind + i];
+	}
+	argv[i] = NULL;
+
+	// Write the updated argc and argv back.
+	*argvp = argv;
+	*argcp = argc - optind;
+
+ out:
+	// Don't return anything in case of an error.
+	if (err != NULL) {
+		sc_cleanup_args(&args);
+	}
+	// Forward the error and return
+	sc_error_forward(errorp, err);
+	return args;
+}
+
+void sc_args_free(struct sc_args *args)
+{
+	if (args != NULL) {
+		free(args->security_tag);
+		args->security_tag = NULL;
+		free(args->executable);
+		args->executable = NULL;
+		free(args);
+	}
+}
+
+void sc_cleanup_args(struct sc_args **ptr)
+{
+	sc_args_free(*ptr);
+	*ptr = NULL;
+}
+
+bool sc_args_is_version_query(struct sc_args *args)
+{
+	if (args == NULL) {
+		die("cannot obtain version query flag from NULL argument parser");
+	}
+	return args->is_version_query;
+}
+
+bool sc_args_is_classic_confinement(struct sc_args * args)
+{
+	if (args == NULL) {
+		die("cannot obtain classic confinement flag from NULL argument parser");
+	}
+	return args->is_classic_confinement;
+}
+
+char *sc_args_security_tag(struct sc_args *args)
+{
+	if (args == NULL) {
+		die("cannot obtain security tag from NULL argument parser");
+	}
+	return args->security_tag;
+}
+
+char *sc_args_executable(struct sc_args *args)
+{
+	if (args == NULL) {
+		die("cannot obtain executable from NULL argument parser");
+	}
+	return args->executable;
+}

--- a/src/snap-confine-args.h
+++ b/src/snap-confine-args.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SC_SNAP_CONFINE_ARGS_H
+#define SC_SNAP_CONFINE_ARGS_H
+
+#include <stdbool.h>
+
+#include "error.h"
+
+/**
+ * Error domain for errors related to argument parsing.
+ **/
+#define SC_ARGS_DOMAIN "args"
+
+enum {
+	/**
+	 * Error indicating that the command line arguments could not be parsed
+	 * correctly and usage message should be displayed to the user.
+	 **/
+	SC_ARGS_ERR_USAGE = 1,
+};
+
+/**
+ * Opaque structure describing command-line arguments to snap-confine.
+ **/
+struct sc_args;
+
+/**
+ * Parse command line arguments for snap-confine.
+ *
+ * Snap confine understands very specific arguments.
+ *
+ * The argument vector can begin with "ubuntu-core-launcher" (with an optional
+ * path) which implies that the first arctual argument (argv[1]) is a copy of
+ * argv[2] and can be discarded.
+ *
+ * The argument vector is scanned, left to right, to look for switches that
+ * start with the minus sign ('-'). Recognized options are stored and
+ * memorized. Unrecognized options return an appropriate error object.
+ *
+ * Currently only one option is understood, that is "--version". It is simply
+ * scanned, memorized and discarded. The presence of this switch can be
+ * retrieved with sc_args_is_version_query().
+ *
+ * After all the option switches are scanned it is expected to scan two more
+ * arguments: the security tag and the name of the executable to run.  An error
+ * object is returned when those is missing.
+ *
+ * Both argc and argv are modified so the caller can look at the first unparsed
+ * argument at argc[0]. This is only done if argument parsing is successful.
+ **/
+__attribute__ ((nonnull(1, 2), warn_unused_result))
+struct sc_args *sc_nonfatal_parse_args(int *argcp, char ***argvp,
+				       struct sc_error **errorp);
+
+/**
+ * Free the object describing command-line arguments to snap-confine.
+ **/
+void sc_args_free(struct sc_args *args);
+
+/**
+ * Cleanup an error with sc_args_free()
+ *
+ * This function is designed to be used with
+ * __attribute__((cleanup(sc_cleanup_args))).
+ **/
+void sc_cleanup_args(struct sc_args **ptr);
+
+/**
+ * Check if snap-confine was invoked with the --version switch.
+ **/
+bool sc_args_is_version_query(struct sc_args *args);
+
+/**
+ * Check if snap-confine was invoked with the --classic switch.
+ **/
+bool sc_args_is_classic_confinement(struct sc_args *args);
+
+/**
+ * Get the security tag passed to snap-confine.
+ *
+ * The return value may be NULL if snap-confine was invoked with --version. It
+ * is never NULL otherwise.
+ *
+ * The return value doesn't need to be freed(). It is bound to the lifetime of
+ * the argument parser.
+ **/
+char *sc_args_security_tag(struct sc_args *args);
+
+/**
+ * Get the executable name passed to snap-confine.
+ *
+ * The return value may be NULL if snap-confine was invoked with --version. It
+ * is never NULL otherwise.
+ *
+ * The return value doesn't need to be freed(). It is bound to the lifetime of
+ * the argument parser.
+ **/
+char *sc_args_executable(struct sc_args *args);
+
+#endif


### PR DESCRIPTION
This patch adds a new module that does what current snap-confine main() does
with regards to argument parsing. The module is fully tested and has simple API
sufficient to drive rest of snap-confine.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>